### PR TITLE
[feat] 리뷰 목록 스켈레톤 구현, 프로그레스바 텍스트 수정, 모임 상세 제목 길이 제한 구현

### DIFF
--- a/src/app/gatherings/detail/[id]/ui.tsx
+++ b/src/app/gatherings/detail/[id]/ui.tsx
@@ -118,7 +118,7 @@ export default function GatheringsDetailPageUI({ params }: PageProps) {
                             />
                         </article>
                         {/* 모임 정보 */}
-                        <article className='max-w-screen-lg sm:w-[30rem] h-[14rem] px-6 py-5 border-2 border-gray-300 bg-white rounded-lg flex flex-col justify-between gap-4'
+                        <article className='max-w-screen-lg sm:w-[30rem] h-[14rem] px-6 py-5 border-2 border-gray-300 bg-white rounded-lg flex flex-col justify-between gap-4 overflow-hidden'
                         >
                             {/* 상단 */}
                             <div className='flex justify-between gap-8'>
@@ -126,13 +126,17 @@ export default function GatheringsDetailPageUI({ params }: PageProps) {
                                 <div className='flex flex-col'>
                                     {/* 제목, 주소 */}
                                     <div className="flex flex-col min-w-0">
-                                        <h2 className="text-xl font-bold max-w-full">
-                                            {detail?.name}
+                                        <h2 className="text-xl font-bold max-w-full" title={detail?.name}>
+                                            {detail?.name
+                                                ? detail.name.length > 20
+                                                    ? detail.name.slice(0, 20) + '...'
+                                                    : detail.name
+                                                : ''}
                                         </h2>
                                         <span className="text-gray-500">{detail?.location || '장소'}</span>
                                     </div>
                                     {/* 날짜 시간 */}
-                                    <div className="flex items-center gap-1 text-sm text-gray-500">
+                                    <div className="flex sm:hidden md:flex items-center gap-1 text-sm text-gray-500">
                                         <span>{formatDate(detail?.dateTime || 'OOOO-OO-OO')}</span>
                                         <span>·</span>
                                         <span>{formatTime(detail?.dateTime || 'OO:OO')}</span>
@@ -216,7 +220,7 @@ export default function GatheringsDetailPageUI({ params }: PageProps) {
                 <section className='w-full h-full px-4 py-4 flex flex-col gap-4 bg-white rounded-lg'>
                     <h1 className='text-lg font-semibold'>다른 참여자들은 이렇게 느꼈어요!</h1>
                     {reviewsLoading ? (
-                        <DetailReviewLoading />
+                        <DetailReviewLoading width='w-full' height='h-32' />
                     ) : (
                         reviews?.data?.map((review: ReviewItem) => (
                             <div

--- a/src/components/gatherings/detail/DetailReviewLoading.tsx
+++ b/src/components/gatherings/detail/DetailReviewLoading.tsx
@@ -1,9 +1,30 @@
-export default function DetailReviewLoading() {
-    return (
-        <section className='w-full h-full px-4 py-4 flex flex-col gap-4 bg-white rounded-lg'>
-            {/* 스켈레톤 */}
-            {/* 페이지 컨버터 */}
-        </section>
-    )
+import { Heart } from 'lucide-react';
+
+interface DetailReviewLoadingProps {
+    width: string;
+    height: string;
 }
 
+/**
+ * 모임 상세 페이지 로딩 스켈레톤
+ * @prop {string} width w-2, w-full, w-[10rem]
+ * @prop {string} height h-2, h-full, h-[10rem]
+ */
+export default function DetailReviewLoading({ width = 'w-1/4', height = 'h-32' }: DetailReviewLoadingProps) {
+    return (
+        <div className={`${width} ${height} m-auto flex flex-col gap-4 animate-pulse`} >
+            {/* 하트 */}
+            <div className='flex gap-1'>{Array.from({ length: 5 }).map((_, index) => (
+                <Heart key={index} className="w-4 h-4 fill-gray-300 text-gray-300" />
+            ))}</div>
+            {/* 본문 */}
+            <div className='w-20 h-2 bg-gray-300 shadow-md rounded' />
+            {/* 닉네임 | 날짜 */}
+            <div className='flex items-center gap-1'>
+                <div className='w-12 h-2 bg-gray-300 shadow-md rounded' />
+                <span className='text-gray-300'>|</span>
+                <div className='w-12 h-2 bg-gray-300 shadow-md rounded' />
+            </div>
+        </div>
+    );
+}

--- a/src/components/gatherings/shared/ui/JoinedCountsProgressBar.tsx
+++ b/src/components/gatherings/shared/ui/JoinedCountsProgressBar.tsx
@@ -1,6 +1,13 @@
+'use client';
+
 import { useMemo } from 'react';
+import { usePathname } from 'next/navigation';
 
 export default function JoinedCountsProgressBar({ participantCount, capacity }: { participantCount: number, capacity: number }) {
+    const pathname = usePathname();
+
+    const hideMinIndicator = pathname.includes('/gatherings/detail');
+
     const percent = useMemo(() => {
         if (!participantCount || !capacity) return 0;
         return Math.min((participantCount / capacity) * 100, 100);
@@ -16,12 +23,14 @@ export default function JoinedCountsProgressBar({ participantCount, capacity }: 
             {/* 최소 인원 인디케이터 */}
             <div
                 className="absolute -top-1 left-0"
-                style={{ left: `calc(${minPercent}% - 8px)` }} // 8px은 인디케이터 반 너비
+                style={{ left: `calc(${minPercent}% - 8px)` }}
             >
                 <div className="w-4 h-4 bg-main-500 rounded-full border-2 border-white shadow" />
-                <span className="absolute left-1/2 -translate-x-1/2 mt-1 text-xs text-main-500 font-semibold whitespace-nowrap">
-                    개설
-                </span>
+                {!hideMinIndicator && (
+                    <span className="absolute left-1/2 -translate-x-1/2 mt-1 text-xs text-main-500 font-semibold whitespace-nowrap">
+                        개설확정
+                    </span>
+                )}
             </div>
             {/* 진행 바 */}
             <div


### PR DESCRIPTION
## 📌 리뷰 목록 스켈레톤 구현
• DetailReviewLoading.tsx
• 캐시 데이터 isLoading시 렌더

## 📌 프로그레스바 텍스트 수정
• JoinedCountsProgressBar.tsx
• 모임 찾기에서는 '개설확정'이 원 아래 표시, 모임 상세는 X

## 📌 모임 상세 제목 길이 제한 구현
• 20자 이하는 그대로 표시, 20자 넘어가면 ...
• truncate는 이미지 비율을 망가뜨리고 sm일 때 레이아웃이 최적화되지 않아서 사용하지 않음