### PR TITLE
[feat] 모임 상세 페이지 리뷰 목록 서버사이드 로드 + useQuery 페이지네이션 구현

### DIFF
--- a/src/app/api/gatherings/detail/reviews/route.ts
+++ b/src/app/api/gatherings/detail/reviews/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 
 /**
- * 모임 리뷰 목록 조회
+ * 리뷰 목록 조회
  * @param request 
  * @method GET
  * @returns 모임 리뷰 목록

--- a/src/app/gatherings/detail/[id]/page.tsx
+++ b/src/app/gatherings/detail/[id]/page.tsx
@@ -1,13 +1,52 @@
+import { Reviews } from '@/types/reviews';
 import GatheringsDetailPageUI from './ui';
 
-/**
- * 페이지 프로퍼티: 서버 컴포넌트 -> 클라이언트 컴포넌트 파라미터 전달
- * @type {Promise<{ id: string }>} params의 비동기 반환 id 값
- */
 export interface PageProps {
-    params: Promise<{ id: string }>;
+    params: { id: string };
 }
 
-export default function GatheringsDetailPage({ params }: PageProps) {
-    return <GatheringsDetailPageUI params={params} />
+async function getDetailReview(id: string): Promise<Reviews> {
+    try {
+        const response = await fetch(`${process.env.API_URI_DEV}/reviews?gatheringId=${id}&limit=4&offset=0`, {
+            next: { revalidate: 60 },
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        });
+
+        const data = await response.json();
+
+        if (
+            data &&
+            Array.isArray(data.data) &&
+            typeof data.totalItemCount === 'number' &&
+            typeof data.currentPage === 'number' &&
+            typeof data.totalPages === 'number'
+        ) {
+            return data as Reviews;
+        } else {
+            console.warn('응답이 Review 타입이 아닙니다:', data);
+            return {
+                data: [],
+                totalItemCount: 0,
+                currentPage: 0,
+                totalPages: 0,
+            };
+        }
+    } catch (error) {
+        console.error('모임 리뷰 조회 Server Error:', error);
+        return {
+            data: [],
+            totalItemCount: 0,
+            currentPage: 0,
+            totalPages: 0,
+        };
+    }
+}
+
+export default async function GatheringsDetailPage({ params }: PageProps) {
+    const { id } = await params;
+    const detailReviews = await getDetailReview(id);
+
+    return <GatheringsDetailPageUI id={id} detailReviews={detailReviews} />
 }

--- a/src/app/gatherings/detail/[id]/ui.tsx
+++ b/src/app/gatherings/detail/[id]/ui.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useFetchGatheringDetail } from '@/hooks/api/useFetchGatheringDetail';
 import { useFetchDetailReview } from '@/hooks/api/useFetchDetailReview';
@@ -11,9 +11,8 @@ import { useLeaveGathering } from '@/hooks/api/useLeaveGathering';
 import { AuthContext } from '@/providers/AuthProvider';
 import { formatDate, formatTime, getTimeRemaining } from '@/components/shared/utils/format';
 import { Heart, Check, UserRoundCheck } from "lucide-react"
-import { ReviewItem } from '@/types/reviews';
+import { ReviewItem, Reviews } from '@/types/reviews';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { PageProps } from './page';
 import Image from 'next/image';
 import ConfirmDialog from '@/components/shared/ui/ConfirmDialog';
 import SaveToggleButton from '@/components/gatherings/shared/ui/SaveToggleButton';
@@ -41,22 +40,29 @@ const handleCopyUrl = () => {
     navigator.clipboard.writeText(currentUrl)
 };
 
-export default function GatheringsDetailPageUI({ params }: PageProps) {
-    const { id } = use(params);
+const LIMIT = 4;
+
+export default function GatheringsDetailPageUI({ id, detailReviews }: { id: string, detailReviews: Reviews }) {
     const { token, userId, loginModalOpen, setLoginModalOpen } = useContext(AuthContext);
 
     const [deleteModalOpen, setDeleteModalOpen] = useState(false);
     const [errorModalOpen, setErrorModalOpen] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
-    const [page, setPage] = useState(1);
+    const [page, setPage] = useState(detailReviews?.currentPage ?? 1);
+    const [reviews, setReviews] = useState<ReviewItem[]>(detailReviews.data);
 
-    const limit = 4;
-    const offset = (page - 1) * limit;
+    const router = useRouter();
+
+    const offset = (page - 1) * LIMIT;
 
     const { detail, participants, isLoading: detailLoading } = useFetchGatheringDetail(Number(id));
     const { data: isParticipated, } = useCheckJoined(Number(id), token);
-    const { data: reviews, isLoading: reviewsLoading } = useFetchDetailReview(Number(id), limit, offset);
-    const totalPages = reviews?.totalPages || 1;
+    const { data: nextPageData, isLoading: reviewsLoading } = useFetchDetailReview(
+        Number(id),
+        LIMIT,
+        offset,
+        page > 1
+    );
 
     const { joinGathering } = useJoinGathering({
         token,
@@ -81,7 +87,11 @@ export default function GatheringsDetailPageUI({ params }: PageProps) {
         }
     });
 
-    const router = useRouter();
+    // 1페이지는 SSR 데이터만, 2페이지부터 useFetchDetailReview로 데이터 추가
+    useEffect(() => {
+        if (page === 1) return;
+        if (nextPageData) setReviews(detailReviews.data.concat(nextPageData.data));
+    }, [page, nextPageData, detailReviews.data]);
 
     const handleDeleteConfirm = () => {
         cancelGathering(Number(id));
@@ -222,7 +232,7 @@ export default function GatheringsDetailPageUI({ params }: PageProps) {
                     {reviewsLoading ? (
                         <DetailReviewLoading width='w-full' height='h-32' />
                     ) : (
-                        reviews?.data?.map((review: ReviewItem) => (
+                        reviews?.map((review: ReviewItem) => (
                             <div
                                 key={review?.id}
                                 className='w-full border-dotted border-b-2 border-main-300 flex flex-col gap-2'>
@@ -246,14 +256,14 @@ export default function GatheringsDetailPageUI({ params }: PageProps) {
                         ))
                     )}
                     {/* 페이지 컨버터 */}
-                    {totalPages >= 1 ? (
+                    {detailReviews?.totalPages >= 1 ? (
                         <div className="flex justify-center items-center gap-2 mt-4">
                             <button
                                 className="w-8 h-8 flex items-center justify-center text-gray-500 transition"
                                 disabled={page === 1}
                                 onClick={() => setPage(page - 1)}
                             >〈</button>
-                            {Array.from({ length: totalPages }).map((_, idx) => (
+                            {Array.from({ length: detailReviews?.totalPages }).map((_, idx) => (
                                 <button
                                     key={idx}
                                     className={`w-8 h-8 flex items-center justify-center rounded-full border ${page === idx + 1 ? 'border-main-500 bg-main-500 text-white font-bold' : 'border-gray-300 bg-white text-gray-500 hover:bg-main-100 transition'}`}
@@ -262,7 +272,7 @@ export default function GatheringsDetailPageUI({ params }: PageProps) {
                             ))}
                             <button
                                 className="w-8 h-8 flex items-center justify-center text-gray-500 transition"
-                                disabled={page === totalPages}
+                                disabled={page === detailReviews?.totalPages}
                                 onClick={() => setPage(page + 1)}
                             >〉</button>
                         </div>

--- a/src/hooks/api/useFetchDetailReview.ts
+++ b/src/hooks/api/useFetchDetailReview.ts
@@ -14,7 +14,8 @@ import axios from 'axios';
 export const useFetchDetailReview = (
     gatheringId: number,
     limit: number,
-    offset: number
+    offset: number,
+    enabled: boolean
 ) => {
     const fetchGatheringReviews = async () => {
         try {
@@ -31,7 +32,7 @@ export const useFetchDetailReview = (
     }
 
     const { data, isLoading, isError } = useQuery({
-        enabled: !!gatheringId,
+        enabled: !!gatheringId && enabled,
         queryKey: ['gatheringReviews', gatheringId],
         queryFn: fetchGatheringReviews,
         refetchOnWindowFocus: false,

--- a/src/store/reviewsStore.ts
+++ b/src/store/reviewsStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import { Reviews } from '@/types/reviews';
+
+/**
+ * SSR 모임 상세 리뷰 목록
+ * @type {Reviews} detailReviews 모임 상세 리뷰 목록
+ * @type {function} setDetailReviews 모임 상세 리뷰 목록 설정 함수
+ * */
+interface DetailReviewsState {
+    detailReviews: Reviews;
+    setDetailReviews: (detailReviews: Reviews) => void;
+}
+
+export const useDetailReviewsStore = create<DetailReviewsState>((set) => ({
+    detailReviews: {
+        data: [],
+        totalItemCount: 0,
+        currentPage: 0,
+        totalPages: 0,
+    },
+    setDetailReviews: (detailReviews: Reviews) =>
+        set((state) => ({
+            detailReviews: {
+                data: state.detailReviews.data.concat(detailReviews.data),
+                totalItemCount: detailReviews.totalItemCount,
+                currentPage: detailReviews.currentPage,
+                totalPages: detailReviews.totalPages,
+            },
+        })),
+}));

--- a/src/types/reviews.ts
+++ b/src/types/reviews.ts
@@ -59,7 +59,7 @@ export interface UserInfo {
  * @type currentPage: 현재 페이지
  * @type totalPages: 총 페이지 수
  */
-export interface Review {
+export interface Reviews {
     data: ReviewItem[];
     totalItemCount: number;
     currentPage: number;


### PR DESCRIPTION
## 📌 모임 상세 페이지 리뷰 목록 서버사이드 + useQuery 페이지네이션 구현
• app/gatherings/detail/page.tsx, app/gatherings/detail/ui.tsx, useFetchDetailReview 
• 4개를 기준으로 하나의 페이지로 삼고, 1 페이지는 ISR로 페이지 생성시 로드하고 2 페이지 부터는 useFetchDetailReview로 로드
• 기존 로직 수정됨