### PR TITLE
[feat] 상단 탭 필터링 기능 구현 및 필터 컴포넌트/훅 분리 

### DIFF
--- a/src/app/reviews/ui.tsx
+++ b/src/app/reviews/ui.tsx
@@ -1,264 +1,156 @@
 'use client';
 
-import { useState , useContext  } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
+import { useContext } from 'react';
 import Image from 'next/image';
 import { Heart } from 'lucide-react';
 import { AuthContext } from '@/providers/AuthProvider';
-
-export enum Category {
-  DALLAEMFIT = 'DALLAEMFIT',
-  WORKATION = 'WORKATION',
-}
-
-export enum DallaemfitType {
-  ALL = 'ALL',
-  OFFICE_STRETCHING = 'OFFICE_STRETCHING',
-  MINDFULNESS = 'MINDFULNESS',
-}
-
-const DALLAEMFIT_LABEL: Record<DallaemfitType, string> = {
-  ALL: '전체',
-  OFFICE_STRETCHING: '오피스 스트레칭',
-  MINDFULNESS: '마인드풀니스',
-};
-
-export interface ReviewGathering {
-  id: number;
-  teamId: string;
-  type: 'DALLAEMFIT' | 'OFFICE_STRETCHING' | 'MINDFULNESS' | 'WORKATION';
-  name: string;
-  dateTime: string;
-  location: string;
-  image: string;
-}
-
-export interface ReviewUser {
-  id: number;
-  name: string;
-  image: string;
-}
-
-interface Review {
-  id: number;
-  score: number;
-  comment: string;
-  createdAt: string;
-  Gathering: ReviewGathering;
-  User: ReviewUser;
-}
-
-const HeartRating = ({ score }: { score: number }) => (
-  <div className="flex gap-[2px]">
-    {[...Array(5)].map((_, i) => (
-      <Heart
-        key={i}
-        className={`w-4 h-4 ${
-          i < score ? 'fill-main-500 stroke-main-500' : 'fill-gray-200 stroke-gray-200'
-        }`}
-      />
-    ))}
-  </div>
-);
+import { useTabFilter } from '@/hooks/gathering/useTabFilter';
+import { useFilteredGatherings } from '@/hooks/gathering/useFilteredGatherings';
+import GatheringsCategoryTabs from '@/components/gatherings/shared/ui/GatheringsCategoryTabs';
+import GatheringsFilterTabs from '@/components/gatherings/shared/ui/GatheringsFilterTabs';
+import TabLocationDateSortControls from '@/components/gatherings/shared/ui/TabLocationDateSortControls';
+import { Review, ReviewItem } from '@/types/reviews';
 
 export default function ReviewPage() {
-  const [filter, setFilter] = useState({
-    category: Category.DALLAEMFIT,
-    type: DallaemfitType.ALL,
-  });
-  const [selectedLocation, setSelectedLocation] = useState('');
-  const [selectedDate, setSelectedDate] = useState('');
-  const [sortBy, setSortBy] = useState('');
+const {
+  filter,
+  selectedLocation,
+  selectedDate,
+  sortBy,
+  setLocation,
+  setDate,
+  setSort,
+  handleCategoryChange,
+  handleTypeChange,
+} = useTabFilter();
+
+const filterState = {
+  filter,
+  selectedLocation,
+  selectedDate,
+  sortBy,
+};
+
   const { token } = useContext(AuthContext);
 
-  const handleCategoryChange = (category: Category) => {
-    setFilter({ category, type: DallaemfitType.ALL });
-  };
+const {
+  data: reviewResponse,
+  isLoading,
+  error,
+} = useFilteredGatherings<Review>('/api/reviews', filterState, token ?? undefined)
 
-  const handleTypeChange = (type: DallaemfitType) => {
-    setFilter((prev) => ({ ...prev, type }));
-  };
-
-  const fetchReviews = async (): Promise<Review[]> => {
-    if (!token) throw new Error('로그인이 필요합니다.');
-
-    const params: Record<string, string> = {};
-    if (filter.category === Category.WORKATION) {
-      params.type = 'WORKATION';
-    } else if (filter.type !== DallaemfitType.ALL) {
-      params.type = filter.type;
-    }
-    if (selectedLocation) params.location = selectedLocation;
-    if (selectedDate) params.date = selectedDate;
-    if (sortBy) {
-      params.sortBy = sortBy;
-      params.sortOrder = 'desc';
-    }
-
-    const res = await axios.get('/api/reviews', {
-      params,
-      headers: { Authorization: `Bearer ${token}` },
-    });
-
-    const result = res.data;
-    return Array.isArray(result) ? result : result.data;
-  };
-
-  const { data: reviews = [], isLoading, error } = useQuery({
-    queryKey: ['allReviews', filter, selectedLocation, selectedDate, sortBy],
-    queryFn: fetchReviews,
-  });
+  const reviews: ReviewItem[] = reviewResponse?.data ?? [];
 
   const average =
     reviews.length > 0
-      ? reviews.reduce((sum, r) => sum + r.score, 0) / reviews.length
+      ? reviews.reduce((sum, r) => sum + r.score, 0)
       : 0;
 
-  const ratingCounts = {
-    5: reviews.filter((r) => r.score === 5).length,
-    4: reviews.filter((r) => r.score === 4).length,
-    3: reviews.filter((r) => r.score === 3).length,
-    2: reviews.filter((r) => r.score === 2).length,
-    1: reviews.filter((r) => r.score === 1).length,
+  const ratingCounts: Record<1 | 2 | 3 | 4 | 5, number> = {
+    5: reviews.filter((r: ReviewItem) => r.score === 5).length,
+    4: reviews.filter((r: ReviewItem) => r.score === 4).length,
+    3: reviews.filter((r: ReviewItem) => r.score === 3).length,
+    2: reviews.filter((r: ReviewItem) => r.score === 2).length,
+    1: reviews.filter((r: ReviewItem) => r.score === 1).length,
   };
+
   const maxCount = Math.max(...Object.values(ratingCounts));
+
+  const HeartRating = ({ score }: { score: number }) => (
+    <div className="flex gap-[2px]">
+      {[...Array(5)].map((_, i) => (
+        <Heart
+          key={i}
+          className={`w-4 h-4 ${
+            i < score ? 'fill-main-500 stroke-main-500' : 'fill-gray-200 stroke-gray-200'
+          }`}
+        />
+      ))}
+    </div>
+  );
 
   return (
     <main className="contents-container">
-      <div className="w-full pt-10 flex items-start gap-4">
-        <Image
-          src="/icons/saved-logo.svg"
-          alt="찜 아이콘"
-          width={70}
-          height={70}
-          className="rounded-full border-2 border-black pointer-events-none"
-          priority
-        />
-        <div>
-          <p className="text-sm text-gray-600">모임 리뷰</p>
-          <p className="text-xl font-bold text-gray-900">다른 사람들의 후기를 참고해보세요 👀</p>
+      <div className="w-full flex flex-col">
+        <div className="w-full pt-10 flex flex-row justify-between items-center">
+          <Image
+            src="/icons/saved-logo.svg"
+            alt="찜 아이콘"
+            width={70}
+            height={70}
+            className="rounded-full border-2 border-black mr-1 pointer-events-none"
+            priority
+          />
+          <div className="w-full flex flex-col justify-start px-2">
+            <p className="text-[#374151] text-sm font-medium mb-2">모임 리뷰</p>
+            <p className="text-gray-900 text-lg font-semibold">다른 사람들의 후기를 참고해보세요 👀</p>
+          </div>
         </div>
+
+        <div className="w-full flex flex-col justify-start py-5">
+          <GatheringsCategoryTabs selected={filter.category} onChange={handleCategoryChange} />
+          {filter.category === 'DALLAEMFIT' && (
+            <GatheringsFilterTabs selected={filter.type} onChange={handleTypeChange} />
+          )}
+        </div>
+
+        <TabLocationDateSortControls
+          selectedLocation={selectedLocation}
+          setLocation={setLocation}
+          selectedDate={selectedDate}
+          setDate={setDate}
+          sortBy={sortBy}
+          setSort={setSort}
+          showSort={true}
+        />
       </div>
 
-      {/* 🔻 필터 */}
-      <div className="py-6">
-        <div className="flex gap-2 mb-2">
-          <button
-            onClick={() => handleCategoryChange(Category.DALLAEMFIT)}
-            className={`px-4 py-1 text-lg font-semibold ${
-              filter.category === Category.DALLAEMFIT ? 'border-b-2 border-black' : ''
-            }`}
-          >
-            E 북적북적 Meet
-          </button>
-          <button
-            onClick={() => handleCategoryChange(Category.WORKATION)}
-            className={`px-4 py-1 text-lg font-semibold ${
-              filter.category === Category.WORKATION ? 'border-b-2 border-black' : ''
-            }`}
-          >
-            I 도란도란 Meet
-          </button>
-        </div>
-        {filter.category === Category.DALLAEMFIT && (
-          <div className="flex gap-2 border-b pb-4">
-            {Object.values(DallaemfitType).map((type) => (
-              <button
-                key={type}
-                onClick={() => handleTypeChange(type)}
-                className={`px-4 py-2 rounded-lg text-sm font-medium ${
-                  filter.type === type ? 'bg-gray-900 text-white' : 'bg-gray-200 text-gray-800'
-                }`}
-              >
-                {DALLAEMFIT_LABEL[type]}
-              </button>
+      <section className="bg-white border border-gray-200 px-6 py-6 rounded-lg mb-10">
+        <div className="flex items-center gap-6">
+          <div className="w-40 flex flex-col items-center">
+            <h2 className="text-2xl font-bold text-gray-900">
+              {average.toFixed(1)}<span className="text-gray-500 text-lg"> / 5</span>
+            </h2>
+            {average > 0 ? (
+              <HeartRating score={Math.round(average)} />
+            ) : (
+              <>
+                <HeartRating score={0} />
+                <span className="text-xs text-gray-400 mt-1">리뷰가 없습니다</span>
+              </>
+            )}
+          </div>
+
+          <div className="flex-1 max-w-[20rem]">
+            {[5, 4, 3, 2, 1].map((rating) => (
+              <div key={rating} className="flex items-center mb-1">
+                <span className="w-6 text-xs">{rating}점</span>
+                <div className="flex-1 bg-gray-100 h-2 rounded-full mx-2 overflow-hidden">
+                  <div
+                    className="h-full bg-main-500 transition-all duration-300"
+                    style={{
+                      width: maxCount
+                        ? `${(ratingCounts[rating as 1 | 2 | 3 | 4 | 5] / maxCount) * 100}%`
+                        : '0%',
+                    }}
+                  />
+                </div>
+                <span className="w-6 text-xs text-right">
+                  {ratingCounts[rating as 1 | 2 | 3 | 4 | 5]}
+                </span>
+              </div>
             ))}
           </div>
-        )}
-      </div>
-
-      {/* 🔻 지역/날짜/정렬 */}
-      <div className="flex items-center gap-3 mb-10">
-        <select
-          value={selectedLocation}
-          onChange={(e) => setSelectedLocation(e.target.value)}
-          className="border px-3 py-2 rounded-lg text-sm"
-        >
-          <option value="">지역 전체</option>
-          <option value="을지로3가">을지로3가</option>
-          <option value="건대입구">건대입구</option>
-          <option value="신림">신림</option>
-          <option value="홍대입구">홍대입구</option>
-        </select>
-        <input
-          type="date"
-          value={selectedDate}
-          onChange={(e) => setSelectedDate(e.target.value)}
-          className="border px-3 py-2 rounded-lg text-sm"
-        />
-        <select
-          value={sortBy}
-          onChange={(e) => setSortBy(e.target.value)}
-          className="ml-auto border px-3 py-2 rounded-lg text-sm"
-        >
-          <option value="">정렬 선택</option>
-          <option value="createdAt">최신순</option>
-          <option value="score">리뷰 높은 순</option>
-          <option value="participantCount">참여 인원 순</option>
-        </select>
-      </div>
-
-      {/* 🔻 평균 평점 섹션 */}
-     <section className="bg-white border border-gray-200 px-6 py-6 rounded-lg mb-10">
-  <div className="flex items-center gap-6">
-    {/* 왼쪽: 평균 점수 */}
-    <div className="w-40 flex flex-col items-center">
-      <h2 className="text-2xl font-bold text-gray-900">
-        {average.toFixed(1)}<span className="text-gray-500 text-lg"> / 5</span>
-      </h2>
-      {average > 0 ? (
-        <HeartRating score={Math.round(average)} />
-      ) : (
-        <>
-          <HeartRating score={0} />
-          <span className="text-xs text-gray-400 mt-1">리뷰가 없습니다</span>
-        </>
-      )}
-    </div>
-
-    {/* 오른쪽: 점수 분포 */}
-    <div className="flex-1 max-w-[20rem]">
-      {[5, 4, 3, 2, 1].map((rating) => (
-        <div key={rating} className="flex items-center mb-1">
-          <span className="w-6 text-xs">{rating}점</span>
-          <div className="flex-1 bg-gray-100 h-2 rounded-full mx-2 overflow-hidden">
-            <div
-              className="h-full bg-main-500 transition-all duration-300"
-              style={{
-                width: maxCount
-                  ? `${(ratingCounts[rating as 1 | 2 | 3 | 4 | 5] / maxCount) * 100}%`
-                  : '0%',
-              }}
-            />
-          </div>
-          <span className="w-6 text-xs text-right">
-            {ratingCounts[rating as 1 | 2 | 3 | 4 | 5]}
-          </span>
         </div>
-      ))}
-    </div>
-  </div>
-</section>
+      </section>
 
-      {/* 🔻 리뷰 리스트 */}
       <div className="flex flex-col gap-4">
         <h3 className="text-lg font-semibold text-gray-900">📝 모든 리뷰</h3>
         {isLoading && <p className="text-gray-500">리뷰 불러오는 중...</p>}
         {error && <p className="text-red-500">에러 발생: {(error as Error).message}</p>}
         {!isLoading &&
           !error &&
-          reviews.map((review) => (
+          reviews.map((review: ReviewItem) => (
             <div key={review.id} className="border rounded-lg p-4 shadow-sm">
               <div className="flex gap-4">
                 <div className="w-[10rem] h-[6rem] relative rounded-lg overflow-hidden">
@@ -273,11 +165,10 @@ export default function ReviewPage() {
                   <HeartRating score={review.score} />
                   <p className="text-sm text-gray-700 mt-2">{review.comment}</p>
                   <p className="text-xs text-gray-400 mt-1">
-                    {/* <Image src='/images/default_profile_image.svg' alt='프로필 이미지' width={32} height={32} className='rounded-full' /> */}
-                     {review.Gathering.name} · {review.Gathering.location}
+                    {review.Gathering.name} · {review.Gathering.location}
                   </p>
                   <p className="text-xs text-gray-400 mt-1">
-                     {review.User.name} |  {new Date(review.createdAt).toLocaleDateString()}
+                    {review.User.name} | {new Date(review.createdAt).toLocaleDateString()}
                   </p>
                 </div>
               </div>

--- a/src/app/saved/ui.tsx
+++ b/src/app/saved/ui.tsx
@@ -16,7 +16,7 @@ const ITEMS_PER_PAGE = 10;
 
 export default function LikeMeetingsPage() {
   const { savedIds: likedList } = useToggleSavedGatherings();
-  const allGatherings = useGatheringsStore((s) => s.gatherings); // ✅ 상태에서 전체 모임 받아오기
+  const allGatherings = useGatheringsStore((s) => s.gatherings); 
 
   const {
     filter,

--- a/src/app/saved/ui.tsx
+++ b/src/app/saved/ui.tsx
@@ -1,75 +1,57 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Gathering } from "@/types/gatherings";
-import { useToggleSavedGatherings } from "@/hooks/gathering/useToggleSavedGatherings";
-import Image from "next/image";
+import Image from 'next/image';
+
+import { Category } from '@/types/tabFilters';
+import { useToggleSavedGatherings } from '@/hooks/gathering/useToggleSavedGatherings';
+import { useGatheringsStore } from '@/store/gatheringsStore'; // ✅ Zustand import
 import GatheringsList from '@/components/gatherings/GatheringsList';
-import axios from 'axios';
-
-export enum Category {
-  DALLAEMFIT = 'DALLAEMFIT',
-  WORKATION = 'WORKATION',
-}
-
-export enum DallaemfitType {
-  ALL = 'ALL',
-  OFFICE_STRETCHING = 'OFFICE_STRETCHING',
-  MINDFULNESS = 'MINDFULNESS',
-}
-
-const DALLAEMFIT_LABEL: Record<DallaemfitType, string> = {
-  ALL: '전체',
-  OFFICE_STRETCHING: '오피스 스트레칭',
-  MINDFULNESS: '마인드풀',
-};
+import GatheringsCategoryTabs from '@/components/gatherings/shared/ui/GatheringsCategoryTabs';
+import GatheringsFilterTabs from '@/components/gatherings/shared/ui/GatheringsFilterTabs';
+import { filterGatherings } from '@/components/gatherings/shared/utils/filterGatherings';
+import { useTabFilter } from '@/hooks/gathering/useTabFilter';
 
 const ITEMS_PER_PAGE = 10;
 
-export default function LikedMeetingsPage() {
-  const { savedIds: likedList, toggleSaved } = useToggleSavedGatherings();
+export default function LikeMeetingsPage() {
+  const { savedIds: likedList } = useToggleSavedGatherings();
+  const allGatherings = useGatheringsStore((s) => s.gatherings); // ✅ 상태에서 전체 모임 받아오기
 
-  const { data: allGatherings = [] } = useQuery<Gathering[]>({
-    queryKey: ['allGatherings'],
-    queryFn: async () => {
-      const res = await axios.get('/api/gatherings');
-      return res.data;
-    },
-  });
+  const {
+    filter,
+    selectedLocation,
+    selectedDate,
+    sortBy,
+    handleCategoryChange,
+    handleTypeChange,
+  } = useTabFilter();
 
-  const [filter, setFilter] = useState({
-    category: Category.DALLAEMFIT,
-    type: DallaemfitType.ALL,
-  });
+  const filterState = {
+    category: filter.category,
+    type: filter.type,
+    selectedLocation,
+    selectedDate,
+    sortBy,
+  };
 
   const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
   const observerRef = useRef<HTMLDivElement | null>(null);
 
-  const filteredGatherings = allGatherings.filter((g) => {
-    if (!likedList.includes(String(g.id))) return false;
-
-    if (filter.category === Category.DALLAEMFIT) {
-      if (filter.type === DallaemfitType.ALL) {
-        return g.type === 'OFFICE_STRETCHING' || g.type === 'MINDFULNESS';
-      } else {
-        return g.type === filter.type;
-      }
-    } else {
-      return g.type === 'WORKATION';
-    }
-  });
-
+  const filteredGatherings = filterGatherings(allGatherings, likedList, filterState);
   const visibleGatherings = filteredGatherings.slice(0, visibleCount);
 
   useEffect(() => {
     if (visibleCount >= filteredGatherings.length) return;
 
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
-        setVisibleCount((prev) => prev + ITEMS_PER_PAGE);
-      }
-    }, { threshold: 1 });
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount(prev => prev + ITEMS_PER_PAGE);
+        }
+      },
+      { threshold: 1 }
+    );
 
     const current = observerRef.current;
     if (current) observer.observe(current);
@@ -79,56 +61,46 @@ export default function LikedMeetingsPage() {
     };
   }, [visibleCount, filteredGatherings.length]);
 
-  const handleCategoryChange = (category: Category) => {
-    setFilter({ category, type: DallaemfitType.ALL });
-    setVisibleCount(ITEMS_PER_PAGE);
-  };
-
-  const handleTypeChange = (type: DallaemfitType) => {
-    setFilter((prev) => ({ ...prev, type }));
-    setVisibleCount(ITEMS_PER_PAGE);
-  };
-
   return (
     <main className="contents-container">
-      <div className="w-full flex flex-col">
-        <div className="w-full pt-10 flex flex-row justify-between items-center">
-          <Image src="/icons/saved-logo.svg" alt="찜 아이콘" width={70} height={70} className="rounded-full border-2 border-black mr-1 pointer-events-none" priority />
-          <div className="w-full flex flex-col justify-start px-2">
-            <p className="text-[#374151] text-sm font-medium mb-2">찜한 모임</p>
-            <p className="text-gray-900 text-lg font-semibold">마감되기 전에 지금 바로 참여해보세요 👀</p>
+      <div className="flex w-full flex-col">
+        {/* 상단 헤더 */}
+        <div className="flex w-full flex-row items-center justify-between pt-10">
+          <Image
+            src="/icons/saved-logo.svg"
+            alt="찜 아이콘"
+            width={70}
+            height={70}
+            className="pointer-events-none mr-1 rounded-full border-2 border-black"
+            priority
+          />
+          <div className="flex w-full flex-col justify-start px-2">
+            <p className="mb-2 text-sm font-medium text-[#374151]">찜한 모임</p>
+            <p className="text-lg font-semibold text-gray-900">
+              마감되기 전에 지금 바로 참여해보세요 👀
+            </p>
           </div>
         </div>
 
-        <div className="w-full flex flex-col justify-start py-5">
-          <div className="flex flex-row">
-            <button onClick={() => handleCategoryChange(Category.DALLAEMFIT)} className={`text-gray-900 text-lg font-semibold px-4 py-1 ${filter.category === 'DALLAEMFIT' ? 'border-b-2 border-gray-900' : ''}`}>주제1</button>
-            <button onClick={() => handleCategoryChange(Category.WORKATION)} className={`text-gray-900 text-lg font-semibold px-4 py-1 ${filter.category === 'WORKATION' ? 'border-b-2 border-gray-900' : ''}`}>주제2</button>
-          </div>
-
+        <div className="flex w-full flex-col justify-start py-5">
+          <GatheringsCategoryTabs
+            selected={filter.category}
+            onChange={handleCategoryChange}
+          />
           {filter.category === Category.DALLAEMFIT && (
-            <div className="w-full flex flex-col justify-start py-5 border-b-2 border-gray-200">
-              <div className="flex flex-row items-center gap-2">
-                {Object.values(DallaemfitType).map((type) => (
-                  <button key={type} onClick={() => handleTypeChange(type)} className={`${filter.type === type ? 'bg-gray-800 text-white' : 'bg-gray-200 text-gray-900'} text-sm font-medium px-4 py-2 rounded-lg`}>
-                    {DALLAEMFIT_LABEL[type]}
-                  </button>
-                ))}
-              </div>
-            </div>
+            <GatheringsFilterTabs
+              selected={filter.type}
+              onChange={handleTypeChange}
+            />
           )}
         </div>
       </div>
 
+      {/* 모임 카드 목록 */}
       <GatheringsList
+        fetchFromApi={false}
         gatherings={visibleGatherings}
-        savedGatheringIds={likedList}
-        onToggleSaved={toggleSaved}
       />
-
-      {visibleGatherings.length < filteredGatherings.length && (
-        <div ref={observerRef} className="h-4" />
-      )}
     </main>
   );
 }

--- a/src/components/gatherings/shared/ui/GatheringsCategoryTabs.tsx
+++ b/src/components/gatherings/shared/ui/GatheringsCategoryTabs.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Category } from '@/types/tabFilters';
+
+interface Props {
+  selected: Category;
+  onChange: (category: Category) => void;
+}
+
+const GatheringsCategoryTabs = ({ selected, onChange }: Props) => {
+  return (
+    <div className="flex flex-row">
+      <button
+        onClick={() => onChange(Category.DALLAEMFIT)}
+        className={`text-gray-900 text-lg font-semibold px-4 py-1 ${
+          selected === Category.DALLAEMFIT ? 'border-b-2 border-gray-900' : ''
+        }`}
+      >
+        E 복적복적 Meet
+      </button>
+      <button
+        onClick={() => onChange(Category.WORKATION)}
+        className={`text-gray-900 text-lg font-semibold px-4 py-1 ${
+          selected === Category.WORKATION ? 'border-b-2 border-gray-900' : ''
+        }`}
+      >
+        I 도란도란 Meet
+      </button>
+    </div>
+  );
+};
+
+export default GatheringsCategoryTabs;

--- a/src/components/gatherings/shared/ui/GatheringsFilterTabs.tsx
+++ b/src/components/gatherings/shared/ui/GatheringsFilterTabs.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { DallaemfitType, DALLAEMFIT_LABEL } from '@/types/tabFilters';
+
+interface Props {
+  selected: DallaemfitType;
+  onChange: (type: DallaemfitType) => void;
+}
+
+const GatheringsFilterTabs = ({ selected, onChange }: Props) => {
+  return (
+    <div className="w-full flex flex-col justify-start py-5 border-b-2 border-gray-200">
+      <div className="flex flex-row items-center gap-2">
+        {Object.values(DallaemfitType).map((type) => (
+          <button
+            key={type}
+            onClick={() => onChange(type)}
+            className={`${
+              selected === type ? 'bg-gray-800 text-white' : 'bg-gray-200 text-gray-900'
+            } text-sm font-medium px-4 py-2 rounded-lg`}
+          >
+            {DALLAEMFIT_LABEL[type]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default GatheringsFilterTabs;

--- a/src/components/gatherings/shared/ui/TabLocationDateSortControls.tsx
+++ b/src/components/gatherings/shared/ui/TabLocationDateSortControls.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+interface Props {
+  selectedLocation: string;
+  setLocation: (location: string) => void;
+  selectedDate: string;
+  setDate: (date: string) => void;
+  sortBy: string;
+  setSort: (sort: string) => void;
+  showSort?: boolean; // ✅ 선택적 props 추가
+}
+
+export default function TabLocationDateSortControls({
+  selectedLocation,
+  setLocation,
+  selectedDate,
+  setDate,
+  sortBy,
+  setSort,
+  showSort = true, // 기본값 true
+}: Props) {
+  return (
+    <div className="flex items-center gap-3 mb-10">
+      <select
+        value={selectedLocation}
+        onChange={(e) => setLocation(e.target.value)}
+        className="border px-3 py-2 rounded-lg text-sm"
+      >
+        <option value="">지역 전체</option>
+        <option value="을지로3가">을지로3가</option>
+        <option value="건대입구">건대입구</option>
+        <option value="신림">신림</option>
+        <option value="홍대입구">홍대입구</option>
+      </select>
+
+      <input
+        type="date"
+        value={selectedDate}
+        onChange={(e) => setDate(e.target.value)}
+        className="border px-3 py-2 rounded-lg text-sm"
+      />
+
+      {showSort && ( // ✅ 조건부 렌더링 추가
+        <select
+          value={sortBy}
+          onChange={(e) => setSort(e.target.value)}
+          className="ml-auto border px-3 py-2 rounded-lg text-sm"
+        >
+          <option value="">정렬 선택</option>
+          <option value="createdAt">최신순</option>
+          <option value="score">리뷰 높은 순</option>
+          <option value="participantCount">참여 인원 순</option>
+        </select>
+      )}
+    </div>
+  );
+}

--- a/src/components/gatherings/shared/utils/filterGatherings.ts
+++ b/src/components/gatherings/shared/utils/filterGatherings.ts
@@ -1,0 +1,39 @@
+// ✅ filterGatherings.ts
+import { Gathering } from '@/types/gatherings';
+import { Category, DallaemfitType } from '@/types/tabFilters';
+
+const DALLAEMFIT_TYPES: DallaemfitType[] = [
+  DallaemfitType.OFFICE_STRETCHING,
+  DallaemfitType.MINDFULNESS,
+];
+
+export function filterGatherings(
+  gatherings: Gathering[],
+  likedIds: string[],
+  filter: { category: Category; type: DallaemfitType }
+): Gathering[] {
+  return gatherings.filter((g) => {
+    const isLiked = likedIds.includes(String(g.id));
+    const isDallaemfit = filter.category === Category.DALLAEMFIT;
+    const isTypeMatched = isDallaemfit
+      ? filter.type === DallaemfitType.ALL
+        ? DALLAEMFIT_TYPES.includes(g.type as DallaemfitType)
+        : g.type === filter.type
+      : g.type === filter.category;
+
+    const passed = isLiked && isTypeMatched;
+
+    if (passed) {
+      console.log('[✅ 통과된 모임]', {
+        id: g.id,
+      isLiked,
+        name: g.name,
+        type: g.type,
+        location: g.location,
+        date: g.dateTime,
+      });
+    }
+
+    return passed;
+  });
+}

--- a/src/hooks/gathering/useFilteredGatherings.ts
+++ b/src/hooks/gathering/useFilteredGatherings.ts
@@ -1,0 +1,46 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import axios from 'axios';
+
+/**
+ * API 결과 타입을 지정할 수 있는 커스텀 훅
+ */
+export function useFilteredGatherings<T = unknown>(
+  apiUrl: string,
+  filterState: {
+    filter: { category: string; type: string };
+    selectedLocation: string;
+    selectedDate: string;
+    sortBy: string;
+  },
+  token?: string
+): UseQueryResult<T, Error> {
+  const { filter, selectedLocation, selectedDate, sortBy } = filterState;
+
+  const queryFn = async (): Promise<T> => {
+    const params: Record<string, string> = {};
+
+    if (filter.category === 'WORKATION') {
+      params.type = 'WORKATION';
+    } else if (filter.type !== 'ALL') {
+      params.type = filter.type;
+    }
+    if (selectedLocation) params.location = selectedLocation;
+    if (selectedDate) params.date = selectedDate;
+    if (sortBy) {
+      params.sortBy = sortBy;
+      params.sortOrder = 'desc';
+    }
+
+    const res = await axios.get(apiUrl, {
+      params,
+      ...(token && { headers: { Authorization: `Bearer ${token}` } }),
+    });
+
+    return res.data as T;
+  };
+
+  return useQuery<T, Error>({
+    queryKey: ['filteredData', filter, selectedLocation, selectedDate, sortBy],
+    queryFn,
+  });
+}

--- a/src/hooks/gathering/useTabFilter.ts
+++ b/src/hooks/gathering/useTabFilter.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { Category, DallaemfitType } from '@/types/tabFilters';
+
+
+export function useTabFilter() {
+  const [filter, setFilter] = useState<{
+    category: Category;
+    type: DallaemfitType;
+  }>({
+    category: Category.DALLAEMFIT,
+    type: DallaemfitType.ALL,
+  });
+
+  const [selectedLocation, setSelectedLocation] = useState('');
+  const [selectedDate, setSelectedDate] = useState('');
+  const [sortBy, setSortBy] = useState('');
+
+  const handleCategoryChange = (category: Category) => {
+    setFilter({ category, type: DallaemfitType.ALL });
+  };
+
+  const handleTypeChange = (type: DallaemfitType) => {
+    setFilter((prev) => ({ ...prev, type }));
+  };
+
+  return {
+    filter,
+    selectedLocation,
+    selectedDate,
+    sortBy,
+    setLocation: setSelectedLocation,
+    setDate: setSelectedDate,
+    setSort: setSortBy,
+    handleCategoryChange,
+    handleTypeChange,
+  };
+}

--- a/src/types/tabFilters.ts
+++ b/src/types/tabFilters.ts
@@ -1,0 +1,26 @@
+
+/**
+ * 메인 탭 필터: 모임 주제
+ */
+export enum Category {
+  DALLAEMFIT = 'DALLAEMFIT',
+  WORKATION = 'WORKATION',
+}
+
+/**
+ * 서브 탭 필터: 달램핏 세부 주제
+ */
+export enum DallaemfitType {
+  ALL = 'ALL',
+  OFFICE_STRETCHING = 'OFFICE_STRETCHING',
+  MINDFULNESS = 'MINDFULNESS',
+}
+
+/**
+ * 서브 탭 라벨 (UI용)
+ */
+export const DALLAEMFIT_LABEL: Record<DallaemfitType, string> = {
+  ALL: '전체',
+  OFFICE_STRETCHING: '엔터테인먼트',
+  MINDFULNESS: '액티비티티',
+};


### PR DESCRIPTION
## 📌 [feat] 상단 탭 필터링 기능 구현
- `src/app/saved/ui.tsx`, `src/app/reviews/ui.tsx`
- 카테고리 및 서브타입 선택 시 상태가 반영되고, 조건에 맞는 모임 목록이 필터링되도록 구현
- 각 페이지에 `useTabFilter` 훅을 적용해 일관된 필터링 구조 유지

## 📌 [feat] 필터 UI 컴포넌트 분리
- `components/gatherings/shared/ui/GatheringsCategoryTabs.tsx` 생성
- `components/gatherings/shared/ui/GatheringsFilterTabs.tsx` 생성
- `components/gatherings/shared/ui/TabLocationDateSortControls.tsx` 생성
- 상단 탭, 서브탭, 지역/날짜/정렬 UI를 재사용 가능한 컴포넌트로 분리

## 📌 [feat] 필터링 유틸 분리 및 개선
- `filterGatherings.ts` 생성 → 찜한 모임 필터링 로직 함수화
- likedList, category, type 기준으로 필터링 처리

## 📌 [feat] API 호출용 커스텀 훅 구현
- `useFilteredGatherings.ts`: queryKey 및 filterState 기반 API 요청 커스터마이징
- `useTabFilter.ts`: 카테고리/타입/지역/날짜/정렬 상태를 하나의 훅에서 관리

## 📌 [chore] 타입 정의 추가
- `tabFilters.ts` 생성
  - Category, DallaemfitType enum 정의
  - DALLAEMFIT_LABEL 상수 정의 (UI용)

---

## ✅ 기타 참고
- `/saved`, `/reviews` 페이지 모두 동일한 필터 구조로 개선