### PR TITLE
[refactor] ConfirmDialog props 수정 & 전용 상태와 텍스트 콜백 설정 함수 생성, alert를 ConfirmDialog로 대체

### DIFF
--- a/src/app/mypage/ui.tsx
+++ b/src/app/mypage/ui.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import ProfileCard from "@/components/mypage/ProfileCard";
 import JoinedGatherings from "@/components/mypage/JoinedGatherings";
-import CreatedReviews from "@/components/mypage/CreatedReviews";
+import MyReviews from "@/components/mypage/MyReviews";
 import CreatedGatherings from "@/components/mypage/CreatedGatherings";
 
 enum MypageTab {
@@ -50,7 +50,7 @@ export default function MyPageUI({ teamId }: { teamId: string }) {
 
           {/* 탭에 따른 내용 */}
           {selectedTab === MypageTab.JoinedGatherings && <JoinedGatherings />}
-          {selectedTab === MypageTab.MyReviews && <CreatedReviews teamId={teamId} />}
+          {selectedTab === MypageTab.MyReviews && <MyReviews teamId={teamId} />}
           {selectedTab === MypageTab.CreatedGatherings && <CreatedGatherings />}
         </div>
       </div>

--- a/src/components/auth/shared/ui/InputField.tsx
+++ b/src/components/auth/shared/ui/InputField.tsx
@@ -13,15 +13,12 @@ interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
 const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
     ({ label, id, type, placeholder, error, errorResponseMessage, disabled, isPasswordVisible, handlePasswordVisibility, ...props }, ref) => (
         <div className="w-full flex flex-col gap-2">
-            <label htmlFor={id} className="block text-sm text-gray-900 font-bold">
-                {label}
-            </label>
+            <label htmlFor={id} className="block text-sm text-gray-900 font-bold">{label}</label>
             <div className='relative'>
                 <input
                     ref={ref}
                     type={label === '비밀번호' ? (isPasswordVisible ? 'text' : 'password') : type}
                     id={id}
-                    disabled={disabled}
                     placeholder={placeholder}
                     aria-invalid={disabled ? (error ? 'true' : 'false') : undefined}
                     className={`block w-full p-2.5 rounded-lg bg-gray-50 text-sm text-gray-900 border-2 focus:outline-none ${error || errorResponseMessage ? 'border-red-600' : 'focus:border-main-300'}`}

--- a/src/components/gatherings/CreateGatheringDialog.tsx
+++ b/src/components/gatherings/CreateGatheringDialog.tsx
@@ -3,15 +3,18 @@
 import { AuthContext } from '@/providers/AuthProvider';
 import { useState, useRef, useEffect, useContext } from "react";
 import { useCreateGathering } from '@/hooks/api/useCreateGathering';
+import { ConfirmDialogState, openConfirmDialog } from '@/components/shared/utils/confirmDialog';
 import { XIcon } from "lucide-react";
+import axios from 'axios';
+import dynamic from 'next/dynamic';
 import SelectionService from "./SelectionService";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import axios from 'axios';
+
+const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 
 export default function CreateGatheringDialog({ onClose }: { onClose: () => void }) {
     const { token } = useContext(AuthContext);
-    const { createGathering } = useCreateGathering(token); // isLoading 제거
 
     // 폼 데이터 상태 관리
     const [formData, setFormData] = useState({
@@ -24,11 +27,11 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
     // 파일명 상태
     const [fileName, setFileName] = useState("");
 
-    // 이미지 파일
-    const [imageFile, setImageFile] = useState<File | null>(null);
-
     // 파일 입력 요소에 접근하기 위한 ref
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // 이미지 파일
+    const [imageFile, setImageFile] = useState<File | null>(null);
 
     // 모임 날짜
     const [meetingDate, setMeetingDate] = useState<Date | null>(null);
@@ -42,6 +45,13 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
     // 제출 상태 관리 (기존 방식 유지)
     const [isSubmitting, setIsSubmitting] = useState(false);
 
+    // 모임 생성 완료/실패 모달
+    const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState>({ open: false, text: '' });
+
+    const { createGathering } = useCreateGathering({
+        token,
+        onCallback: (message) => openConfirmDialog(setConfirmDialog, message),
+    });
 
     // 입력 필드 변경 핸들러
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -59,6 +69,8 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
             type
         }));
     };
+
+
     // 모달이 열릴 때 스크롤 방지 및 레이아웃 시프트 방지
     useEffect(() => {
         const originalBodyOverFlow = document.body.style.overflow;
@@ -167,9 +179,10 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
         // 모임 생성 요청
         createGathering(apiFormData, {
             onSuccess: () => {
-                alert('모임 생성 완료');
-                setIsSubmitting(false);
-                onClose();
+                openConfirmDialog(setConfirmDialog, '모임 생성 완료', () => {
+                    setIsSubmitting(false);
+                    onClose();
+                });
             },
             onError: (error: unknown) => {
                 console.error('모임 생성 실패:', error);
@@ -177,11 +190,11 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
 
                 if (axios.isAxiosError(error)) {
                     const serverError = error?.response?.data?.error;
-                    alert(serverError?.message || '에러가 발생했습니다.');
+                    openConfirmDialog(setConfirmDialog, serverError?.message);
                 } else if (error instanceof Error) {
-                    alert(error.message);
+                    openConfirmDialog(setConfirmDialog, error.message);
                 } else {
-                    alert('알 수 없는 에러가 발생했습니다.');
+                    openConfirmDialog(setConfirmDialog, '알 수 없는 에러가 발생했습니다');
                 }
             }
         });
@@ -338,6 +351,13 @@ export default function CreateGatheringDialog({ onClose }: { onClose: () => void
                     </form>
                 </div>
             </div>
+            {/* 모임 생성 완료/실패 모달 */}
+            <ConfirmDialog
+                open={confirmDialog.open}
+                text={confirmDialog.text}
+                onClose={() => setConfirmDialog({ open: false, text: '' })}
+                onConfirm={confirmDialog.onConfirm}
+            />
         </div>
     );
 }

--- a/src/components/gatherings/detail/Footer.tsx
+++ b/src/components/gatherings/detail/Footer.tsx
@@ -1,6 +1,19 @@
 import { Gathering } from '@/types/gatherings';
 
-export default function Footer({ userId, detail, isParticipated, leaveGathering, joinGathering, token, setDeleteModalOpen, handleCopyUrl, id, setLoginModalOpen }: { userId: number, detail: Gathering, isParticipated: boolean, leaveGathering: (id: number) => void, joinGathering: (id: number) => void, token: string, setDeleteModalOpen: (open: boolean) => void, handleCopyUrl: () => void, id: string, setLoginModalOpen: (open: boolean) => void }) {
+interface FooterProps {
+    userId: number;
+    detail: Gathering;
+    isParticipated: boolean;
+    token: string;
+    id: string;
+    handleCopyUrl: () => void;
+    leaveGathering: (id: number) => void;
+    joinGathering: (id: number) => void;
+    setDialogOpen: (open: boolean) => void;
+    setLoginDialogOpen: (open: boolean) => void;
+}
+
+export default function Footer({ userId, detail, isParticipated, leaveGathering, joinGathering, token, setDialogOpen, handleCopyUrl, id, setLoginDialogOpen }: FooterProps) {
     return (
         <footer className='sticky bottom-0 w-full h-16 border-t border-gray-300 bg-white' >
             <div className='max-w-screen-lg h-full mx-auto px-4 md:px-20 flex justify-between items-center'>
@@ -8,16 +21,18 @@ export default function Footer({ userId, detail, isParticipated, leaveGathering,
                     <span className='font-semibold'>Meet Meet Together</span>
                     <span className='text-xs font-medium'>모임은 여러분을 기다리고 있어요!</span>
                 </div>
+                {/* 모임 생성자 권한 확인 */}
                 {userId === detail?.createdBy ?
                     <div className='flex justify-between sm:justify-end gap-2'>
                         <button type="button"
-                            onClick={() => { setDeleteModalOpen(true) }}
+                            onClick={() => { setDialogOpen(true) }}
                             className='w-24 h-[60%] py-1 bg-button-text text-button border-button border-1 rounded-lg cursor-pointer hover:opacity-60 transition duration-300 ease-in'>삭제하기</button>
                         <button type="button"
                             onClick={handleCopyUrl}
                             className='w-24 h-[60%] py-1 bg-button text-button-text rounded-lg cursor-pointer hover:opacity-60 transition duration-300 ease-in'>공유하기</button>
                     </div>
                     :
+                    // 모임 참가 여부 확인 (생성자가 아닌 경우)
                     isParticipated ? (
                         <button type="button"
                             onClick={() => leaveGathering(Number(id))}
@@ -25,7 +40,7 @@ export default function Footer({ userId, detail, isParticipated, leaveGathering,
                     ) : (
                         <button type="button"
                             onClick={() => {
-                                if (!token) setLoginModalOpen(true);
+                                if (!token) setLoginDialogOpen(true);
                                 else joinGathering(Number(id))
                             }}
                             className='w-24 h-[60%] py-1 bg-button text-button-text rounded-lg cursor-pointer hover:opacity-60 transition duration-300 ease-in'>참여하기</button>

--- a/src/components/gatherings/detail/GatheringDetailUI.tsx
+++ b/src/components/gatherings/detail/GatheringDetailUI.tsx
@@ -9,8 +9,9 @@ import { useJoinGathering } from '@/hooks/api/useJoinGathering';
 import { useCancelGathering } from '@/hooks/api/useCancelGathering';
 import { useLeaveGathering } from '@/hooks/api/useLeaveGathering';
 import { AuthContext } from '@/providers/AuthProvider';
+import { ConfirmDialogState, openConfirmDialog } from '@/components/shared/utils/confirmDialog';
 import { ReviewItem, Reviews } from '@/types/reviews';
-import ConfirmDialog from '@/components/shared/ui/ConfirmDialog';
+import dynamic from 'next/dynamic';
 import InformationLoading from '@/components/gatherings/detail/loading/InformationLoading';
 import ThumbnailLoading from '@/components/gatherings/detail/loading/ThumbnailLoading';
 import ReviewLoading from '@/components/gatherings/detail/loading/ReviewLoading';
@@ -19,6 +20,8 @@ import Information from '@/components/gatherings/detail/Information';
 import Review from '@/components/gatherings/detail/Review';
 import PageConverter from '@/components/gatherings/detail/PageConverter';
 import Footer from '@/components/gatherings/detail/Footer';
+
+const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 
 export interface Participant {
     teamId: number;
@@ -42,13 +45,11 @@ const handleCopyUrl = () => {
 const LIMIT = 4;
 
 export default function GatheringsDetailUI({ id, detailReviews }: { id: string, detailReviews: Reviews }) {
-    const { token, userId, loginModalOpen, setLoginModalOpen } = useContext(AuthContext);
+    const { token, userId, loginDialogOpen, setLoginDialogOpen } = useContext(AuthContext);
 
-    const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-    const [errorModalOpen, setErrorModalOpen] = useState(false);
-    const [errorMessage, setErrorMessage] = useState('');
     const [page, setPage] = useState(detailReviews?.currentPage ?? 1);
     const [reviews, setReviews] = useState<ReviewItem[]>(detailReviews.data);
+    const [dialog, setDialog] = useState<ConfirmDialogState>({ open: false, text: '' });
 
     const router = useRouter();
 
@@ -65,28 +66,17 @@ export default function GatheringsDetailUI({ id, detailReviews }: { id: string, 
 
     const { joinGathering } = useJoinGathering({
         token,
-        onErrorCallback: (message) => {
-            setErrorMessage(message);
-            setErrorModalOpen(true);
-        }
+        onCallback: (message) => openConfirmDialog(setDialog, message)
     });
-    const { leaveGathering } = useLeaveGathering(
-        {
-            token,
-            onErrorCallback: (message) => {
-                setErrorMessage(message);
-                setErrorModalOpen(true);
-            }
-        });
+    const { leaveGathering } = useLeaveGathering({
+        token,
+        onCallback: (message) => openConfirmDialog(setDialog, message)
+    });
     const { cancelGathering } = useCancelGathering({
         token,
-        onErrorCallback: (message) => {
-            setErrorMessage(message);
-            setErrorModalOpen(true);
-        }
+        onCallback: (message, onConfirm) => openConfirmDialog(setDialog, message, onConfirm)
     });
 
-    // 1페이지는 SSR 데이터만, 2페이지부터 useFetchDetailReview로 데이터 추가
     useEffect(() => {
         if (page === 1) return;
         if (nextPageData) setReviews(detailReviews.data.concat(nextPageData.data));
@@ -94,8 +84,7 @@ export default function GatheringsDetailUI({ id, detailReviews }: { id: string, 
 
     const handleDeleteConfirm = () => {
         cancelGathering(Number(id));
-        router.replace('/gatherings');
-        setDeleteModalOpen(false);
+        setDialog((prev) => ({ ...prev, open: false }));
     };
 
     return (
@@ -130,18 +119,31 @@ export default function GatheringsDetailUI({ id, detailReviews }: { id: string, 
                 </section>
             </main >
             {/* 모임 참가 Footer */}
-            <Footer userId={userId} detail={detail} isParticipated={isParticipated} leaveGathering={leaveGathering} joinGathering={joinGathering} token={token!} setDeleteModalOpen={setDeleteModalOpen} handleCopyUrl={handleCopyUrl} id={id} setLoginModalOpen={setLoginModalOpen} />
-            <ConfirmDialog open={loginModalOpen} onClose={() => setLoginModalOpen(false)} text='로그인이 필요합니다.' needLogin={true} />
-            <ConfirmDialog
-                open={deleteModalOpen}
-                text="모임을 삭제 하시겠습니까?"
-                onClose={() => setDeleteModalOpen(false)}
-                onConfirm={handleDeleteConfirm}
+            <Footer
+                token={token!}
+                userId={userId}
+                id={id}
+                detail={detail}
+                isParticipated={isParticipated}
+                handleCopyUrl={handleCopyUrl}
+                leaveGathering={leaveGathering}
+                joinGathering={joinGathering}
+                setLoginDialogOpen={setLoginDialogOpen}
+                setDialogOpen={(open: boolean) => {
+                    if (open) openConfirmDialog(setDialog, '모임을 삭제 하시겠습니까?', handleDeleteConfirm);
+                    else setDialog((prev) => ({ ...prev, open: false }));
+                }}
             />
             <ConfirmDialog
-                open={errorModalOpen}
-                text={errorMessage}
-                onClose={() => setErrorModalOpen(false)}
+                open={loginDialogOpen}
+                text='로그인이 필요합니다'
+                onClose={() => setLoginDialogOpen(false)}
+                onCallback={() => router.push('/login')} />
+            <ConfirmDialog
+                open={dialog.open}
+                text={dialog.text}
+                onClose={() => setDialog((prev) => ({ ...prev, open: false }))}
+                onConfirm={dialog.onConfirm}
             />
         </>
     );

--- a/src/components/mypage/CreateReviewDialog.tsx
+++ b/src/components/mypage/CreateReviewDialog.tsx
@@ -3,9 +3,12 @@
 import { useState, useContext } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { useCreateReview } from '@/hooks/api/useCreateReview';
+import dynamic from 'next/dynamic';
+
+const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 
 interface ReviewDialogProps {
-  reviewData: {
+  reviewFormData: {
     teamId: string;
     gatheringId: number;
     userId: number;
@@ -14,29 +17,30 @@ interface ReviewDialogProps {
 }
 
 export default function CreateReviewDialog({
-  reviewData,
+  reviewFormData,
   onClose,
 }: ReviewDialogProps) {
   const { token } = useContext(AuthContext);
 
   const [score, setScore] = useState(1);
   const [comment, setComment] = useState('');
+  const [confirmDialog, setConfirmDialog] = useState<{
+    open: boolean;
+    text: string;
+    onConfirm?: () => void;
+  }>({
+    open: false,
+    text: '',
+  });
 
-  const { createReview } = useCreateReview(onClose);
+  const { createReview } = useCreateReview({
+    token,
+    onCallback: (message) => openConfirmDialog(message)
+  });
 
-  const handleSubmit = () => {
-    if (!token) {
-      alert('로그인이 필요합니다.');
-      return;
-    }
+  const openConfirmDialog = (text: string, onConfirm?: () => void) => setConfirmDialog({ open: true, text, onConfirm });
 
-    createReview({
-      gatheringId: reviewData.gatheringId,
-      score,
-      comment,
-      token,
-    });
-  };
+  const handleSubmit = () => createReview({ gatheringId: reviewFormData.gatheringId, score, comment, });
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -75,6 +79,12 @@ export default function CreateReviewDialog({
           </button>
         </div>
       </div>
+      <ConfirmDialog
+        open={confirmDialog.open}
+        text={confirmDialog.text}
+        onClose={() => setConfirmDialog({ open: false, text: '' })}
+        onConfirm={confirmDialog.onConfirm}
+      />
     </div>
   );
 }

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -6,20 +6,22 @@ import { useContext, useState } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { formatDate, formatTime, getTimeRemaining } from '../shared/utils/format';
 import { UserRoundCheck, CheckCircle, Hand } from "lucide-react"
-import ConfirmDialog from '@/components/shared/ui/ConfirmDialog';
 import Image from 'next/image';
+import dynamic from 'next/dynamic';
+
+const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 
 export default function JoinedGatherings() {
+  const { token } = useContext(AuthContext);
+
   const [errorModalOpen, setErrorModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-
-  const { token } = useContext(AuthContext);
 
   const { data: gatherings = [], isLoading, error } = useFetchJoinedGatherings(token!);
 
   const { leaveGathering } = useLeaveGathering({
     token,
-    onErrorCallback: (message) => {
+    onCallback: (message) => {
       setErrorMessage(message);
       setErrorModalOpen(true);
     },
@@ -161,7 +163,6 @@ export default function JoinedGatherings() {
         </div>
       ))}
 
-      {/* 에러 확인용 */}
       <ConfirmDialog
         open={errorModalOpen}
         text={errorMessage}

--- a/src/components/mypage/MyReviews.tsx
+++ b/src/components/mypage/MyReviews.tsx
@@ -7,13 +7,15 @@ import { formatDate, formatTime } from '../shared/utils/format';
 import { JoinedGathering } from '@/types/gatherings';
 import { UserRoundCheck } from 'lucide-react';
 import Image from 'next/image';
-import CreateReviewDialog from './CreateReviewDialog';
+import dynamic from 'next/dynamic';
 
-export default function CreatedReviews({ teamId }: { teamId: string }) {
+const CreateReviewDialog = dynamic(() => import('./CreateReviewDialog'), { ssr: false });
+
+export default function MyReviews({ teamId }: { teamId: string }) {
   const { token, userId } = useContext(AuthContext);
 
   const [reviews, setReviews] = useState(0);
-  const [selectedReviewData, setSelectedReviewData] = useState<{
+  const [reviewableGathering, setReviewableGathering] = useState<{
     teamId: string;
     userId: number;
     gatheringId: number
@@ -98,7 +100,7 @@ export default function CreatedReviews({ teamId }: { teamId: string }) {
                   <button
                     type="button"
                     className="max-w-36 padding-button rounded-lg bg-main-500 text-sm text-white cursor-pointer hover:opacity-70"
-                    onClick={() => setSelectedReviewData({ teamId, userId: userId, gatheringId: Number(gathering.id) })}
+                    onClick={() => setReviewableGathering({ teamId, userId: userId, gatheringId: Number(gathering.id) })}
                   >
                     리뷰 작성하기
                   </button>
@@ -110,10 +112,10 @@ export default function CreatedReviews({ teamId }: { teamId: string }) {
       )}
 
       {/* 리뷰 작성 모달 */}
-      {selectedReviewData && (
+      {reviewableGathering && (
         <CreateReviewDialog
-          reviewData={selectedReviewData}
-          onClose={() => setSelectedReviewData(null)}
+          reviewFormData={reviewableGathering}
+          onClose={() => setReviewableGathering(null)}
         />
       )}
     </div >

--- a/src/components/shared/ui/ConfirmDialog.tsx
+++ b/src/components/shared/ui/ConfirmDialog.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
 
 interface CheckingModalProps {
@@ -6,27 +5,25 @@ interface CheckingModalProps {
     text: string;
     onClose: () => void;
     onConfirm?: () => void;
-    needLogin?: boolean;
+    onCallback?: () => void;
 }
 
 /**
- * 프로젝트 공용 팝업 모달
+ * 프로젝트 공통 모달
  * @param open 모달 열기 여부
  * @param text 모달에 표시할 텍스트
  * @param onClose 닫기 함수
  * @param onConfirm 확인 함수
- * @param needLogin 로그인 필요 여부 (로그인 페이지로 리다이렉트)
+ * @param onCallback 전달받을 콜백 함수
  * @returns 모달 팝업
  */
-export default function ConfirmDialog({ open, text, onClose, onConfirm, needLogin }: CheckingModalProps) {
-    const router = useRouter();
-
+export default function ConfirmDialog({ open, text, onClose, onConfirm, onCallback }: CheckingModalProps) {
     if (!open) return null;
 
     const handleConfirm = () => {
         onClose();
         if (onConfirm) onConfirm();
-        else if (needLogin) router.push('/login');
+        if (onCallback) onCallback();
     };
 
     return (

--- a/src/components/shared/utils/confirmDialog.ts
+++ b/src/components/shared/utils/confirmDialog.ts
@@ -1,0 +1,25 @@
+/**
+ * ConfirmDialog의 상태(열림/닫힘, 메시지, 확인 콜백)를 하나의 객체로 관리하는 타입
+ * @type {boolean} open 모달이 열려 있는지 여부 (true: 열림, false: 닫힘)
+ * @type {string} text 모달에 표시할 메시지(텍스트)
+ * @type {function} onConfirm 확인 버튼 클릭 시 실행할 콜백 함수
+ */
+export interface ConfirmDialogState {
+    open: boolean;
+    text: string;
+    onConfirm?: () => void;
+}
+
+/**
+ * ConfirmDialog를 열기 위한 헬퍼 함수
+ * @param setDialog 모달 상태를 관리하는 함수
+ * @param text 모달에 표시할 메시지(텍스트)
+ * @param onConfirm 확인 버튼 클릭 시 실행할 콜백 함수
+ */
+export function openConfirmDialog(
+    setDialog: React.Dispatch<React.SetStateAction<ConfirmDialogState>>,
+    text: string,
+    onConfirm?: () => void
+) {
+    setDialog({ open: true, text, onConfirm });
+}

--- a/src/hooks/api/useCancelGathering.ts
+++ b/src/hooks/api/useCancelGathering.ts
@@ -1,18 +1,22 @@
 'use client';
 
-import { useGatheringsStore } from '@/store/gatheringsStore';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useGatheringsStore } from '@/store/gatheringsStore';
 import { GatheringApiParams } from '@/types/gatheringApi';
+import { useRouter } from 'next/navigation';
 import axios from 'axios';
 
 /** 모임 삭제 훅
 * @param token 토큰
-* @param onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
+* @param onCallback 모달에 표시할 메세지를 전달
 * @returns {function} cancelGathering - 모임 삭제 함수
 */
-export const useCancelGathering = ({ token, onErrorCallback }: GatheringApiParams) => {
+export const useCancelGathering = ({ token, onCallback }: GatheringApiParams) => {
     const queryClient = useQueryClient();
+
     const removeGathering = useGatheringsStore((s) => s.removeGathering);
+
+    const router = useRouter();
 
     const cancelGathering = useMutation({
         mutationFn: async (id: number) => {
@@ -24,14 +28,14 @@ export const useCancelGathering = ({ token, onErrorCallback }: GatheringApiParam
             removeGathering(id);
             queryClient.invalidateQueries({ queryKey: ["gatherings", "infinite"] });
             queryClient.invalidateQueries({ queryKey: ["createdGatherings", token] });
-            alert('모임을 삭제했습니다.');
+            onCallback?.('모임을 삭제했습니다', () => router.replace('/gatherings'));
         },
         onError: (error) => {
             if (axios.isAxiosError(error)) {
                 const serverError = error?.response?.data?.error;
-                onErrorCallback?.(serverError?.message || '에러가 발생했습니다.');
+                onCallback?.(serverError?.message || '에러가 발생했습니다');
             } else {
-                onErrorCallback?.(error.message);
+                onCallback?.(error.message);
             }
         }
     });

--- a/src/hooks/api/useCreateGathering.ts
+++ b/src/hooks/api/useCreateGathering.ts
@@ -1,14 +1,16 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { GatheringApiParams } from '@/types/gatheringApi';
 import axios from 'axios';
 
 /**
  * 모임 생성 훅
- * @param token 토큰
+* @param token 토큰
+* @param onCallback 모달에 표시할 메세지를 전달
  * @returns {function} createGathering - 모임 생성 함수
  */
-export const useCreateGathering = (token: string | null) => {
+export const useCreateGathering = ({ token, onCallback }: GatheringApiParams) => {
     const queryClient = useQueryClient();
 
     const createGathering = useMutation({
@@ -25,13 +27,14 @@ export const useCreateGathering = (token: string | null) => {
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['gatherings', 'infinite'] });
             queryClient.invalidateQueries({ queryKey: ["createdGatherings", token] });
+            onCallback?.('모임을 생성했습니다');
         },
         onError: (error) => {
             if (axios.isAxiosError(error)) {
                 const serverError = error?.response?.data?.error;
-                alert(serverError?.message || '에러가 발생했습니다.');
+                onCallback?.(serverError?.message || '에러가 발생했습니다');
             } else {
-                alert(error.message);
+                onCallback?.(error.message);
             }
         }
     });

--- a/src/hooks/api/useCreateReview.ts
+++ b/src/hooks/api/useCreateReview.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { GatheringApiParams } from '@/types/gatheringApi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 
@@ -7,36 +8,34 @@ interface CreateReviewParams {
     gatheringId: number;
     score: number;
     comment: string;
-    token: string;
 }
 
 /**
- * 나의 리뷰 생성 훅
+ * 리뷰 작성 훅
  * @param onSuccessCallback 
  * @returns {function} mutateCreateMyReview - 리뷰 생성 함수
  */
 
-export const useCreateReview = (onSuccessCallback: () => void) => {
+export const useCreateReview = ({ token, onCallback }: GatheringApiParams) => {
     const queryClient = useQueryClient();
 
     const createReview = useMutation({
-        mutationFn: async ({ gatheringId, score, comment, token }: CreateReviewParams) => {
+        mutationFn: async ({ gatheringId, score, comment }: CreateReviewParams) => {
             if (!token) throw new Error('로그인이 필요합니다.');
             const response = await axios.post(`/api/reviews`, { gatheringId, score, comment }, { headers: { Authorization: `Bearer ${token}` } });
             return response.data;
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['myGatheringReviews'] });
+            queryClient.invalidateQueries({ queryKey: ["myReviews"] });
             queryClient.invalidateQueries({ queryKey: ["gatheringReviews"] });
-            alert('리뷰가 성공적으로 등록되었습니다.');
-            onSuccessCallback();
+            onCallback?.('리뷰가 성공적으로 등록되었습니다');
         },
         onError: (error) => {
             if (axios.isAxiosError(error)) {
                 const serverError = error?.response?.data?.error;
-                alert(serverError?.message || '리뷰 등록에 실패했습니다.');
+                onCallback?.(serverError?.message || '리뷰 등록에 실패했습니다');
             } else {
-                alert(error.message);
+                onCallback?.(error.message);
             }
         }
     });

--- a/src/hooks/api/useJoinGathering.ts
+++ b/src/hooks/api/useJoinGathering.ts
@@ -4,34 +4,32 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { GatheringApiParams } from '@/types/gatheringApi';
 import axios from 'axios';
 
-/** 모임 참가 훅
+/** 모임 참여 훅
 * @param token 토큰
-* @param onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
+* @param onCallback 모달에 표시할 메세지를 전달
 * @returns {function} joinGathering - 모임 참가 함수
 */
-export const useJoinGathering = ({ token, onErrorCallback }: GatheringApiParams) => {
+export const useJoinGathering = ({ token, onCallback }: GatheringApiParams) => {
     const queryClient = useQueryClient();
 
     const joinGathering = useMutation({
         mutationFn: async (id: number) => {
             if (!token) throw new Error('로그인이 필요합니다.');
-            const response = await axios.post(`/api/gatherings/join?id=${id}`, {}, {
-                headers: { Authorization: `Bearer ${token}` }
-            });
+            const response = await axios.post(`/api/gatherings/join?id=${id}`, {}, { headers: { Authorization: `Bearer ${token}` } });
             return response.data;
         },
         onSuccess: (_, id) => {
             queryClient.invalidateQueries({ queryKey: ["gatheringDetail", id] });
             queryClient.invalidateQueries({ queryKey: ["checkGatheringJoined"] });
             queryClient.invalidateQueries({ queryKey: ["joinedGatherings", token] });
-            alert('참여 완료했습니다.');
+            onCallback?.('참여 완료했습니다');
         },
         onError: (error) => {
             if (axios.isAxiosError(error)) {
                 const serverError = error?.response?.data?.error;
-                onErrorCallback?.(serverError?.message || '에러가 발생했습니다.');
+                onCallback?.(serverError?.message || '에러가 발생했습니다');
             } else {
-                onErrorCallback?.(error.message);
+                onCallback?.(error.message);
             }
         }
     });

--- a/src/hooks/api/useLeaveGathering.ts
+++ b/src/hooks/api/useLeaveGathering.ts
@@ -6,10 +6,10 @@ import axios from 'axios';
 
 /** 모임 참여 취소 훅
 * @param token 토큰
-* @param onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
+* @param onCallback 모달에 표시할 메세지를 전달
 * @returns {function} leaveGathering - 모임 참여 취소 함수
 */
-export const useLeaveGathering = ({ token, onErrorCallback }: GatheringApiParams) => {
+export const useLeaveGathering = ({ token, onCallback }: GatheringApiParams) => {
     const queryClient = useQueryClient();
 
     const leaveGathering = useMutation({
@@ -22,14 +22,14 @@ export const useLeaveGathering = ({ token, onErrorCallback }: GatheringApiParams
             queryClient.invalidateQueries({ queryKey: ["gatheringDetail", id] });
             queryClient.invalidateQueries({ queryKey: ["checkGatheringJoined"] });
             queryClient.invalidateQueries({ queryKey: ["joinedGatherings", token] });
-            alert('참여 취소했습니다.');
+            onCallback?.('참여 취소했습니다');
         },
         onError: (error) => {
             if (axios.isAxiosError(error)) {
                 const serverError = error?.response?.data?.error;
-                onErrorCallback?.(serverError?.message || '에러가 발생했습니다.');
+                onCallback?.(serverError?.message || '에러가 발생했습니다');
             } else {
-                onErrorCallback?.(error.message);
+                onCallback?.(error.message);
             }
         }
     });

--- a/src/lib/queryKey/gatheringKey.ts
+++ b/src/lib/queryKey/gatheringKey.ts
@@ -18,4 +18,4 @@ export const gatheringKeys = {
 
 // ["joinedGatherings", token] 마이페이지 '참여중인 모임'
 // ["createdGatherings", token] - 마이페이지 '내가 만든 모임'
-// ["myGatheringReviews", token] 마이페이지 '나의 리뷰'
+// ["myReviews", token] 마이페이지 '나의 리뷰'

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -4,12 +4,14 @@ import { usePathname, useRouter } from 'next/navigation';
 import { createContext, useState, Dispatch, SetStateAction, useEffect } from "react";
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
-import ConfirmDialog from '@/components/shared/ui/ConfirmDialog';
+import dynamic from 'next/dynamic';
+
+const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 
 type AuthContextType = {
     token: string | null;
-    loginModalOpen: boolean;
-    setLoginModalOpen: Dispatch<SetStateAction<boolean>>;
+    loginDialogOpen: boolean;
+    setLoginDialogOpen: Dispatch<SetStateAction<boolean>>;
     setToken: Dispatch<SetStateAction<string | null>>;
     signup: (email: string, password: string, name: string, companyName: string) => Promise<void>;
     signin: (email: string, password: string) => Promise<void>;
@@ -20,8 +22,8 @@ type AuthContextType = {
 
 export const AuthContext = createContext<AuthContextType>({
     token: null,
-    loginModalOpen: false,
-    setLoginModalOpen: () => { },
+    loginDialogOpen: false,
+    setLoginDialogOpen: () => { },
     setToken: () => { },
     signup: async () => { },
     signin: async () => { },
@@ -36,8 +38,8 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     const [userId, setUserId] = useState(0);
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [previousPath, setPreviousPath] = useState<string>('/');
-    const [loginModalOpen, setLoginModalOpen] = useState(false);
-
+    const [loginDialogOpen, setLoginDialogOpen] = useState(false);
+    const [signupDialogOpen, setSignupDialogOpen] = useState(false);
     const queryClient = useQueryClient();
 
     const router = useRouter();
@@ -47,7 +49,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         try {
             const result = await axios.post('/api/auth/signup', { email, password, name, companyName })
             if (result.status === 200) {
-                alert('회원가입이 완료되었습니다.')
+                setSignupDialogOpen(true);
                 router.replace('/login')
             }
         } catch (error) {
@@ -115,7 +117,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
     useEffect(() => {
         // 마이페이지 접근 시 로그인 확인
-        if (!isLoading && !token && pathname.startsWith('/mypage')) setLoginModalOpen(true);
+        if (!isLoading && !token && pathname.startsWith('/mypage')) setLoginDialogOpen(true);
         // 로그인 후 이전 경로 저장
         if (pathname !== '/login' && !pathname.includes('/auth/')) setPreviousPath(pathname);
         // 로그인 후 로그인 페이지 접근 시 이전 경로로 이동
@@ -123,17 +125,27 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
     }, [isLoading, token, pathname, router, previousPath]);
 
     const handleLoginModalConfirm = () => {
-        setLoginModalOpen(false);
+        setLoginDialogOpen(false);
         router.replace('/login');
     };
 
+    const handleSignupModalConfirm = () => {
+        setSignupDialogOpen(false);
+        router.replace('/');
+    };
+
     return (
-        <AuthContext value={{ token, userName, userId, loginModalOpen, setLoginModalOpen, setToken, signup, signin, signout }}>
+        <AuthContext value={{ token, userName, userId, loginDialogOpen, setLoginDialogOpen, setToken, signup, signin, signout }}>
             {children}
             <ConfirmDialog
-                open={loginModalOpen}
+                open={loginDialogOpen}
                 onClose={handleLoginModalConfirm}
-                text="로그인이 필요합니다."
+                text="로그인이 필요합니다"
+            />
+            <ConfirmDialog
+                open={signupDialogOpen}
+                onClose={handleSignupModalConfirm}
+                text="회원가입이 완료되었습니다"
             />
         </AuthContext>
     );

--- a/src/types/gatheringApi.ts
+++ b/src/types/gatheringApi.ts
@@ -1,9 +1,9 @@
 /**
  * 모임 API 파라미터
  * @type {string | null} token 토큰
- * @type {function} onErrorCallback 에러 콜백 함수 (모달에 표시할 메세지를 전달 받음)
- */
+ * @type {function} onCallback 모달에 표시할 메세지를 전달, 모달 확인 시 실행할 함수를 전달
+*/
 export interface GatheringApiParams {
     token: string | null;
-    onErrorCallback?: (msg: string) => void;
+    onCallback?: (msg: string, onConfirm?: () => void) => void;
 }


### PR DESCRIPTION
## 📌 ConfirmDialog props 수정 & 전용 상태와 텍스트 콜백 설정 함수 생성
• ConfirmDialog.tsx
• needLogin 삭제, onCallback을 전달받아 handleConfirm에서 곧바로 실행 (범용 모달이므로 로그인을 직접 유도하지 않음)
• components/shared/utils/confirmDialog.ts
• ConfirmDialog를 열기 위한 헬퍼 함수와 타입을 정의


## 📌 alert를 ConfirmDialog로 대체
• 컴포넌트
• CreateGatheringDialog, GatheringsDetailUI, CreateReviewDialog, JoinedGatherings, MyReviews
• 훅
• useCreateGathering, useCancelGathering, useJoinGathering, useLeaveGathering, useCreateReview 