### PR TITLE
[refactor] API 라우트 호출 경로에 apiPaths > EXTERNAL_PATHS 적용

### DIFF
--- a/src/app/api/auths/signin/route.ts
+++ b/src/app/api/auths/signin/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 로그인
@@ -12,7 +14,7 @@ export async function POST(request: NextRequest) {
     if (!email || !password) return new NextResponse(JSON.stringify({ error: '이메일과 비밀번호는 필수입니다' }), { status: 400 });
 
     try {
-        const response = await axios.post(`${process.env.API_URI_DEV}/auths/signin`, { email, password })
+        const response = await apiServer.post(EXTERNAL_PATHS.signin, { email, password })
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;

--- a/src/app/api/auths/signout/route.ts
+++ b/src/app/api/auths/signout/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
+
 
 /**
  * 로그아웃
@@ -7,7 +10,7 @@ import axios, { AxiosError } from 'axios';
  */
 export async function POST() {
     try {
-        const response = await axios.post(`${process.env.API_URI_DEV}/auths/signout`)
+        const response = await apiServer.post(EXTERNAL_PATHS.signout)
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;

--- a/src/app/api/auths/signup/route.ts
+++ b/src/app/api/auths/signup/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 회원가입
@@ -12,7 +14,7 @@ export async function POST(request: NextRequest) {
     if (!email || !password || !name || !companyName) return new NextResponse(JSON.stringify({ error: '이메일, 비밀번호, 닉네임, 회사명은 필수 입력입니다' }), { status: 400 });
 
     try {
-        const response = await axios.post(`${process.env.API_URI_DEV}/auths/signup`, {
+        const response = await apiServer.post(EXTERNAL_PATHS.signup, {
             email,
             password,
             name,

--- a/src/app/api/auths/user/route.ts
+++ b/src/app/api/auths/user/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 유저 정보 조회
@@ -13,7 +15,7 @@ export async function GET(request: NextRequest) {
   if (!token) return new NextResponse(JSON.stringify({ error: '토큰이 필요합니다' }), { status: 401 });
 
   try {
-    const response = await axios.get(`${process.env.API_URI_DEV}/auths/user`, { headers: { Authorization: token! } });
+    const response = await apiServer.get(EXTERNAL_PATHS.user, { headers: { Authorization: token! } });
     return new NextResponse(JSON.stringify(response.data), { status: 200 });
   } catch (error) {
     const err = error as AxiosError;
@@ -38,16 +40,11 @@ export async function PUT(request: NextRequest) {
     const companyName = formData.get('companyName') as string;
     const imageFile = formData.get('image') as File;
 
-    // 서버로 전송할 FormData 생성
     const serverFormData = new FormData();
     serverFormData.append('companyName', companyName);
     if (imageFile && imageFile.size > 0) serverFormData.append('image', imageFile);
 
-    const response = await axios.put(
-      `${process.env.API_URI_DEV}/auths/user`,
-      serverFormData,
-      { headers: { Authorization: token! } }
-    );
+    const response = await apiServer.put(EXTERNAL_PATHS.user, serverFormData, { headers: { Authorization: token! } });
 
     return new NextResponse(JSON.stringify(response.data), { status: 200 });
   } catch (error) {

--- a/src/app/api/gatherings/cancel/route.ts
+++ b/src/app/api/gatherings/cancel/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 모임 취소
@@ -10,14 +12,14 @@ import axios, { AxiosError } from 'axios';
  */
 export async function PUT(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
-    const id = searchParams.get('id');
+    const id = Number(searchParams.get('id'));
     const token = request.headers.get('Authorization');
 
     if (!id) return new NextResponse(JSON.stringify({ error: '모임 id가 필요합니다' }), { status: 400 });
     if (!token) return new NextResponse(JSON.stringify({ error: '토큰이 필요합니다' }), { status: 401 });
 
     try {
-        const response = await axios.put(`${process.env.API_URI_DEV}/gatherings/${id}/cancel`, {}, { headers: { 'Authorization': token } });
+        const response = await apiServer.put(EXTERNAL_PATHS.cancelGathering(id), {}, { headers: { 'Authorization': token } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;

--- a/src/app/api/gatherings/detail/route.ts
+++ b/src/app/api/gatherings/detail/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 모임 상세 조회
@@ -9,12 +11,12 @@ import axios, { AxiosError } from 'axios';
  */
 export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
-    const id = searchParams.get('id');
+    const id = Number(searchParams.get('id'));
 
     if (!id) return new NextResponse(JSON.stringify({ error: '모임 id가 필요합니다' }), { status: 400 });
 
     try {
-        const response = await axios.get(`${process.env.API_URI_DEV}/gatherings/${id}`, { params: { teamId: process.env.TEAM_ID_DEV, id } });
+        const response = await apiServer.get(EXTERNAL_PATHS.fetchGatheringDetail(id), { params: { teamId: process.env.TEAM_ID_DEV, id } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;

--- a/src/app/api/gatherings/join/route.ts
+++ b/src/app/api/gatherings/join/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 모임 참여 
@@ -10,14 +12,14 @@ import axios, { AxiosError } from 'axios';
  */
 export async function POST(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
-    const id = searchParams.get('id');
+    const id = Number(searchParams.get('id'));
     const token = request.headers.get('Authorization');
 
     if (!id) return new NextResponse(JSON.stringify({ error: '모임 id가 필요합니다' }), { status: 400 });
     if (!token) return new NextResponse(JSON.stringify({ error: '토큰이 필요합니다' }), { status: 401 });
 
     try {
-        const response = await axios.post(`${process.env.API_URI_DEV}/gatherings/${id}/join`, {}, { headers: { 'Authorization': token } });
+        const response = await apiServer.post(EXTERNAL_PATHS.joinGathering(id), {}, { headers: { 'Authorization': token } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;

--- a/src/app/api/gatherings/joined/route.ts
+++ b/src/app/api/gatherings/joined/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 모임 참여 확인
@@ -11,7 +13,7 @@ import axios, { AxiosError } from 'axios';
 export async function GET(request: NextRequest) {
     try {
         const searchParams = request.nextUrl.searchParams;
-        const response = await axios.get(`${process.env.API_URI_DEV}/gatherings/joined`, {
+        const response = await apiServer.get(EXTERNAL_PATHS.checkJoined, {
             params: Object.fromEntries(searchParams),
             headers: {
                 'Authorization': request.headers.get('Authorization'),

--- a/src/app/api/gatherings/leave/route.ts
+++ b/src/app/api/gatherings/leave/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 모임 참여 취소
@@ -7,17 +9,18 @@ import axios, { AxiosError } from 'axios';
  * @param request - 모임 ID
  * @method DELETE
  * @returns 성공 메세지
- */
+*/
 export async function DELETE(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
-    const id = searchParams.get('id');
+    const id = Number(searchParams.get('id'));
     const token = request.headers.get('Authorization');
 
     if (!id) return new NextResponse(JSON.stringify({ error: '모임 id가 필요합니다' }), { status: 400 });
     if (!token) return new NextResponse(JSON.stringify({ error: '토큰이 필요합니다' }), { status: 401 });
 
+    const response = await apiServer.delete(EXTERNAL_PATHS.leaveGathering(id), { headers: { 'Authorization': token } });
+
     try {
-        const response = await axios.delete(`${process.env.API_URI_DEV}/gatherings/${id}/leave`, { headers: { 'Authorization': token } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;

--- a/src/app/api/gatherings/participants/route.ts
+++ b/src/app/api/gatherings/participants/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 모임 참여자 목록 조회    
@@ -7,16 +9,16 @@ import axios, { AxiosError } from 'axios';
  * @param request - 모임 ID
  * @method GET
  * @returns 해당 모임의 참가자 목록 조회
- */
+*/
 export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
-    const id = searchParams.get('id');
+    const id = Number(searchParams.get('id'));
     const token = request.headers.get('Authorization');
 
     if (!id) return new NextResponse(JSON.stringify({ error: '모임 id가 필요합니다' }), { status: 400 });
 
     try {
-        const response = await axios.get(`${process.env.API_URI_DEV}/gatherings/${id}/participants`, { headers: { 'Authorization': token } });
+        const response = await apiServer.get(EXTERNAL_PATHS.fetchGatheringParticipants(id), { headers: { 'Authorization': token } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
         const err = error as AxiosError;

--- a/src/app/api/gatherings/route.ts
+++ b/src/app/api/gatherings/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 모임 생성 API
@@ -10,12 +12,13 @@ import axios, { AxiosError } from 'axios';
  */
 export async function POST(request: NextRequest) {
     const token = request.headers.get('Authorization');
+
     try {
         const formData = await request.formData();
 
         if (!token) return new NextResponse(JSON.stringify({ error: '토큰이 필요합니다' }), { status: 401 });
 
-        const response = await axios.post(`${process.env.API_URI_DEV}/gatherings`, formData, {
+        const response = await apiServer.post(EXTERNAL_PATHS.createGathering, formData, {
             headers: {
                 'Authorization': token!,
                 'Content-Type': 'multipart/form-data',
@@ -40,7 +43,7 @@ export async function GET(request: NextRequest) {
 
     try {
         const searchParams = request.nextUrl.searchParams;
-        const response = await axios.get(`${process.env.API_URI_DEV}/gatherings`, {
+        const response = await apiServer.get(EXTERNAL_PATHS.fetchGatherings, {
             params: Object.fromEntries(searchParams),
             headers: {
                 'Authorization': token!,

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
 import axios, { AxiosError } from 'axios';
+import { apiServer } from '@/lib/api/axios';
 
 /**
  * 리뷰 목록 조회
@@ -13,7 +15,7 @@ export async function GET(request: NextRequest) {
   const token = request.headers.get('Authorization');
 
   try {
-    const response = await axios.get(`${process.env.API_URI_DEV}/reviews`, {
+    const response = await apiServer.get(EXTERNAL_PATHS.fetchReviews, {
       params: Object.fromEntries(searchParams),
       headers: {
         Authorization: token!,
@@ -37,8 +39,8 @@ export async function POST(request: NextRequest) {
   try {
     const { gatheringId, score, comment } = await request.json();
 
-    const response = await axios.post(
-      `${process.env.API_URI_DEV}/reviews`,
+    const response = await apiServer.post(
+      EXTERNAL_PATHS.createReview,
       { gatheringId, score, comment },
       { headers: { Authorization: request.headers.get('Authorization') } }
     );

--- a/src/hooks/api/gatherings/detail/useFetchGatheringDetailReview.ts
+++ b/src/hooks/api/gatherings/detail/useFetchGatheringDetailReview.ts
@@ -19,7 +19,7 @@ export const useFetchGatheringDetailReview = (
     offset: number,
     enabled: boolean
 ) => {
-    const fetchGatheringReviews = async () => {
+    const fetchGatheringDetailReviews = async () => {
         try {
             const response = await apiClient.get(INTERNAL_PATHS.fetchReviews, { params: { gatheringId, limit, offset } });
             return response.data;
@@ -34,7 +34,7 @@ export const useFetchGatheringDetailReview = (
     const { data, isLoading, isError } = useQuery({
         enabled: !!gatheringId && enabled,
         queryKey: ['gatheringReviews', gatheringId],
-        queryFn: fetchGatheringReviews,
+        queryFn: fetchGatheringDetailReviews,
     })
 
     return { data, isLoading, isError }

--- a/src/lib/api/apiPaths.ts
+++ b/src/lib/api/apiPaths.ts
@@ -1,23 +1,34 @@
-/** 외부 경로
- * @description API 라우트, 클라이언트 -> 백엔드 서버
-
+/** 외부 경로: 클라이언트, API 라우트 -> 백엔드 서버
+ * @string signin -> 로그인
+ * @string signout -> 로그아웃
+ * @string signup -> 회원가입
+ * @string user -> 유저 정보 조회
+ * @string fetchGatherings -> 모임 목록 조회
+ * @string createGathering -> 모임 생성
+ * @function joinGathering -> 모임 참여
+ * @function leaveGathering -> 모임 참여 취소
  */
 export const EXTERNAL_PATHS = {
+    signin: '/auths/signin',
+    signout: '/auths/signout',
+    signup: '/auths/signup',
+    user: '/auths/user',
+
     fetchGatherings: '/gatherings',
     createGathering: '/gatherings',
     fetchGatheringDetail: (id: number) => `/gatherings/${id}`,
     joinGathering: (id: number) => `/gatherings/${id}/join`,
     cancelGathering: (id: number) => `/gatherings/${id}/cancel`,
     leaveGathering: (id: number) => `/gatherings/${id}/leave`,
-    fetchJoinedCheck: (queries: string) => `/gatherings/joined?${queries}`,
+
+    checkJoined: '/gatherings/joined',
     fetchGatheringParticipants: (id: number) => `/gatherings/${id}/participants`,
     fetchGatheringReviews: (queries: string) => `/reviews?${queries}`,
     createReview: '/reviews',
+    fetchReviews: '/reviews',
 } as const;
 
-/** 내부 경로
- * @description 클라이언트 -> API 라우트
- * @example INTERNAL_PATHS.createGathering() -> /api/gatherings
+/** 내부 경로: 클라이언트 -> API 라우트
  * @string signin -> 로그인
  * @string signout -> 로그아웃
  * @string signup -> 회원가입
@@ -35,23 +46,24 @@ export const EXTERNAL_PATHS = {
  * @function fetchGatheringReviews -> 모임 상세 리뷰 조회
  */
 export const INTERNAL_PATHS = {
-    signin: '/auths/signin',
-    signout: '/auths/signout',
-    signup: '/auths/signup',
-    user: '/auths/user',
+    signin: '/api/auths/signin',
+    signout: '/api/auths/signout',
+    signup: '/api/auths/signup',
+    user: '/api/auths/user',
 
     fetchGatherings: '/api/gatherings',
     createGathering: '/api/gatherings',
+    fetchGatheringDetail: (id: number) => `/api/gatherings/detail?id=${id}`,
     joinGathering: (id: number) => `/api/gatherings/join?id=${id}`,
     cancelGathering: (id: number) => `/api/gatherings/cancel?id=${id}`,
     leaveGathering: (id: number) => `/api/gatherings/leave?id=${id}`,
+
     fetchPaginatedGatherings: (page: number, limit: number) => `/api/gatherings?offset=${(page - 1) * limit}&limit=${limit}`,
-    fetchGatheringDetail: (id: number) => `/api/gatherings/detail?id=${id}`,
-    checkJoined: (queries: string) => `/api/gatherings/joined?${queries}`,
     fetchGatheringParticipants: (id: number) => `/api/gatherings/participants?id=${id}`,
-    fetchCreatedGatherings: (userId: number) => `/api/gatherings?createdBy=${userId}&limit=1000`,
-    fetchJoinedGatherings: `/api/gatherings/joined?&limit=1000`,
     fetchGatheringReviews: (gatheringId: number, limit?: number, offset?: number) => `/api/gatherings/detail/reviews?gatheringId=${gatheringId}&limit=${limit}&offset=${offset}`,
+    fetchCreatedGatherings: (userId: number) => `/api/gatherings?createdBy=${userId}&limit=1000`,
+    checkJoined: (queries: string) => `/api/gatherings/joined?${queries}`,
+    fetchJoinedGatherings: `/api/gatherings/joined?&limit=1000`,
     createReview: `/api/reviews`,
     fetchReviews: `/api/reviews`,
 } as const;

--- a/src/lib/api/axios.ts
+++ b/src/lib/api/axios.ts
@@ -1,24 +1,15 @@
 import axios from 'axios';
 
 /**
- * axios 인스턴스 API 클라이언트
+ * axios 클라이언트 인스턴스
  * @param baseURL - API 기본 URL
  * @param withCredentials - 쿠키 포함 여부
- * @warning 외부경로에는 사용하지 말 것
+ * @warning 외부 경로에는 사용하지 말 것
  */
 export const apiClient = axios.create({
     baseURL: process.env.NEXT_PUBLIC_BASE_URI,
     withCredentials: true,
 });
-
-const parseAxiosError = (error: unknown, message = '요청 중 에러가 발생했습니다.') => {
-    if (axios.isAxiosError(error)) {
-        const serverError = error?.response?.data?.error;
-        if (serverError && typeof serverError === 'object' && 'message' in serverError) return serverError.message;
-        if (error?.response?.data?.message) return error.response.data.message;
-    }
-    return message;
-}
 
 // 요청 인터셉터: headers에 토큰 추가
 apiClient.interceptors.request.use(
@@ -40,3 +31,24 @@ apiClient.interceptors.response.use(
         return Promise.reject(error);
     }
 );
+
+// 에러 메세지 파싱
+const parseAxiosError = (error: unknown, message = '요청 중 에러가 발생했습니다.') => {
+    if (axios.isAxiosError(error)) {
+        const serverError = error?.response?.data?.error;
+        if (serverError && typeof serverError === 'object' && 'message' in serverError) return serverError.message;
+        if (error?.response?.data?.message) return error.response.data.message;
+    }
+    return message;
+}
+
+/**
+ * axios 서버 인스턴스
+ * @param baseURL - 기본 URL
+ * @param withCredentials - 쿠키 포함 여부
+ * @warning 외부 경로에는 사용하지 말 것
+ */
+export const apiServer = axios.create({
+    baseURL: process.env.API_URI_DEV,
+    withCredentials: true,
+});

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -4,6 +4,7 @@ import { createContext, useState, Dispatch, SetStateAction, useEffect } from "re
 import { usePathname, useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { apiClient } from '@/lib/api/axios';
 import axios from 'axios';
 import dynamic from 'next/dynamic';
 
@@ -62,7 +63,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
     const signup = async (email: string, password: string, name: string, companyName: string) => {
         try {
-            const result = await axios.post(INTERNAL_PATHS.signup, { email, password, name, companyName })
+            const result = await apiClient.post(INTERNAL_PATHS.signup, { email, password, name, companyName })
             if (result.status === 200) {
                 setSignupDialogOpen(true);
                 router.replace('/login')
@@ -74,11 +75,11 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
     const signin = async (email: string, password: string) => {
         try {
-            const result = await axios.post(INTERNAL_PATHS.signin, { email, password });
+            const result = await apiClient.post(INTERNAL_PATHS.signin, { email, password });
             if (result.status === 200) {
                 localStorage.setItem('token', result.data.token);
                 setToken(result.data.token);
-                await fetchUser(result.data.token);
+                await fetchUser();
                 router.replace(previousPath);
             }
         } catch (error) {
@@ -86,9 +87,9 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         }
     }
 
-    const fetchUser = async (token: string) => {
+    const fetchUser = async () => {
         try {
-            const result = await axios.get(INTERNAL_PATHS.user, { headers: { Authorization: `Bearer ${token}` } });
+            const result = await apiClient.get(INTERNAL_PATHS.user);
             if (result.status === 200) {
                 setUserName(result.data.name);
                 setUserId(result.data.id);


### PR DESCRIPTION
## 📌 API 라우트 경로를 EXTERNAL_PATHS 적용
• EXTERNAL_PATHS
• apiServer 새로 생성 -> API 라우트에서 백엔드 서버용으로 요청
• API 라우트에서 사용 예시: `await apiServer.post(EXTERNAL_PATHS.joinGathering(id))`
