### PR TITLE
[feature, refactor] 전역 모임 아이템 오버레이 구현, 마이페이지 리스트 로딩 UI 구현, 참여중인 모임의 인디케이터 버튼 & 오버레이 조건 수정

### DIFF
--- a/src/components/mypage/CreateReviewDialog.tsx
+++ b/src/components/mypage/CreateReviewDialog.tsx
@@ -44,7 +44,7 @@ export default function CreateReviewDialog({
   const handleSubmit = () => createReview({ gatheringId: reviewFormData.gatheringId, score, comment, });
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+    <div className="dialog-background">
       <div className="w-full max-w-md p-6 rounded-md bg-white shadow-md flex flex-col gap-4">
         <h2 className="text-xl font-semibold">리뷰 남기기</h2>
         <label className="block">만족스러운 경험이었나요?</label>

--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -4,8 +4,12 @@ import { useFetchCreatedGatherings } from '@/hooks/api/mypage/useFetchCreatedGat
 import { useContext } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { formatDate, formatTime, getTimeRemaining } from '@/components/shared/utils/date';
-import { UserRoundCheck, Hand } from "lucide-react"
+import { UserRoundCheck } from "lucide-react"
 import Image from 'next/image';
+import OverlayForDisabled from '../shared/ui/OverlayForDisabled';
+import dynamic from 'next/dynamic';
+
+const LoadingUI = dynamic(() => import('@/components/mypage/LoadingUI'), { ssr: false });
 
 /** 마이페이지 내가 만든 모임 */
 export default function CreatedGatherings() {
@@ -13,9 +17,9 @@ export default function CreatedGatherings() {
 
   const { data: gatherings = [], isLoading, error } = useFetchCreatedGatherings(token!, userId);
 
-  if (isLoading) return <div className="text-center text-gray-500">로딩 중...</div>;
-  if (error) return <p className="text-center text-red-500">에러 발생: {(error as Error).message}</p>;
-  if (!isLoading && !error && gatherings.length === 0) return <p className="text-center text-gray-700">내가 만든 모임이 없어요</p>;
+  if (isLoading) return <LoadingUI width="w-full" height="h-32" />;
+  if (error) return <p className="text-center text-red-500">에러: {(error as Error).message}</p>;
+  if (!isLoading && !error && gatherings.length === 0) return <p className="text-center text-gray-500">내가 만든 모임이 없어요</p>;
 
   return (
     <div className='px-4 flex flex-col gap-2'>
@@ -27,16 +31,11 @@ export default function CreatedGatherings() {
               key={gathering.id}
               className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
             >
-              {/* 마감된 모임 오버레이 */}
-              {new Date(gathering.registrationEnd) < new Date() && (
-                <div className="absolute bg-black/90 inset-0 z-20 flex items-center justify-center text-center rounded-xl">
-                  <div className="px-4 py-2 rounded-lg flex gap-1 text-sm text-white">
-                    <Hand className="w-4 h-4 text-main-400" />
-                    <span>마감되었습니다</span>
-                  </div>
-                </div>
-              )}
-
+              <OverlayForDisabled
+                filterings={getTimeRemaining(gathering?.registrationEnd) === '마감됨' && gathering.participantCount < 5}
+                notice="마감되었습니다"
+                reason="(모집 마감)"
+              />
               {/* 좌측 */}
               <article className='relative'>
                 <div className="relative px-3 bg-white/80 rounded-full flex items-center text-xs">

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -5,10 +5,12 @@ import { useLeaveGathering } from '@/hooks/api/gatherings/detail/useLeaveGatheri
 import { useContext, useState } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { formatDate, formatTime, getTimeRemaining } from '../shared/utils/date';
-import { UserRoundCheck, CheckCircle, Hand } from "lucide-react"
-import Image from 'next/image';
+import { UserRoundCheck, CheckCircle } from "lucide-react"
 import dynamic from 'next/dynamic';
+import Image from 'next/image';
+import OverlayForDisabled from '../shared/ui/OverlayForDisabled';
 
+const LoadingUI = dynamic(() => import('@/components/mypage/LoadingUI'), { ssr: false });
 const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 
 /** 마이페이지 참여중인 모임 */
@@ -37,9 +39,9 @@ export default function JoinedGatherings() {
     return a.isCompleted ? 1 : -1;
   });
 
-  if (isLoading) return <div className="flex h-[100px] w-full items-center justify-center">로딩 중...</div>;
-  if (error) return <div className="text-red-500">에러 발생: {error.message}</div>;
-  if (gatherings.length === 0) return <div className="text-gray-500">참여한 모임이 없습니다.</div>;
+  if (isLoading) return <LoadingUI width="w-full" height="h-32" />;
+  if (error) return <div className="text-red-500">에러: {error.message}</div>;
+  if (gatherings.length === 0) return <div className="text-gray-500 text-center">참여한 모임이 없습니다</div>;
 
   return (
     <div className='px-4 flex flex-col gap-2'>
@@ -48,15 +50,12 @@ export default function JoinedGatherings() {
           key={data.id}
           className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
         >
-          {/* 마감된 모임 오버레이 */}
-          {new Date(data.registrationEnd) < new Date() && (
-            <div className="absolute bg-black/90 inset-0 z-20 flex items-center justify-center text-center rounded-xl">
-              <div className="px-4 py-2 rounded-lg flex gap-1 text-sm text-white">
-                <Hand className="w-4 h-4 text-main-400" />
-                <span>마감되었습니다</span>
-              </div>
-            </div>
-          )}
+          {/* 마감 완료 및 5명 미만 */}
+          <OverlayForDisabled
+            filterings={getTimeRemaining(data?.registrationEnd) === '마감됨' && data?.participantCount < 5}
+            notice="모집이 취소된 모임입니다"
+            reason="(모집 마감 및 최소 인원 미달)"
+          />
 
           {/* 좌측 */}
           <article className='relative'>
@@ -73,41 +72,30 @@ export default function JoinedGatherings() {
               className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
             />
           </article>
+
           {/* 우측 */}
           <div className='flex flex-col justify-between'>
             {/* 모임 정보 */}
             <div className='flex flex-col gap-1'>
               <div className='flex items-center gap-1'>
-                {/* 마감 완료 및 개설 확정시 '이용 완료' */}
-                {data?.isCompleted ? (
-                  data.participantCount >= 5 ? (
-                    <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">
-                      이용 완료
-                    </div>
-                  ) : (
-                    <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">
-                      개설대기
-                    </div>
-                  )
-                ) : (
-                  <>
-                    {/* 마감 전: 이용 예정은 무조건 */}
-                    <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs">
-                      이용 예정
-                    </div>
-                    {data.participantCount >= 5 ? (
-                      // 마감 전 + 5명 이상: 개설확정
-                      <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs flex items-center gap-1">
-                        <CheckCircle className="w-4 h-4 text-white" />
-                        개설확정
-                      </div>
-                    ) : (
-                      // 마감 전 + 5명 미만: 개설대기
-                      <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">
-                        개설대기
-                      </div>
-                    )}
-                  </>
+                {/* 마감 완료 및 5명 이상 모집 및 모임 후 '이용 완료' */}
+                {getTimeRemaining(data?.registrationEnd) === '마감됨' && data?.participantCount >= 5 && data?.isCompleted && (
+                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">이용 완료</div>
+                )}
+                {/* 마감 미완료 및 모임 전 '이용 예정' */}
+                {getTimeRemaining(data?.registrationEnd) !== '마감됨' && !data?.isCompleted && (
+                  <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs">이용 예정</div>
+                )}
+                {/* 마감 미완료 및 5명 이상 모집 '개설 확정'  */}
+                {getTimeRemaining(data?.registrationEnd) !== '마감됨' && data?.participantCount >= 5 && (
+                  <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs flex items-center gap-1">
+                    <CheckCircle className="w-4 h-4 text-white" />
+                    개설 확정
+                  </div>
+                )}
+                {/* 마감 미완료 및 5명 미만 시 '개설 대기' */}
+                {getTimeRemaining(data?.registrationEnd) !== '마감됨' && data?.participantCount < 5 && (
+                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">개설 대기</div>
                 )}
               </div>
               <h1 className="text-xl font-semibold">{data?.name}</h1>
@@ -130,36 +118,34 @@ export default function JoinedGatherings() {
               </div>
             </div>
 
-            {/* 버튼  */}
-            <div>
-              {data?.isCompleted && data?.participantCount >= 5 ? (
-                data.isReviewed ? (
+            {/* 개설 확정 모임은 참여 상태라면 리뷰 작성이 가능*/}
+            {data?.participantCount >= 5 && (
+              <div>
+                {data.isReviewed ? (
                   <button
                     type="button"
-                    className="max-w-36 padding-button rounded-lg bg-button text-button-text text-sm cursor-pointer hover:opacity-60 transition duration-300 ease-in"
+                    className="padding-button rounded-lg bg-button text-button-text text-sm cursor-pointer hover:opacity-60 transition duration-300 ease-in"
                   >
                     내가 쓴 리뷰 보기
                   </button>
                 ) : (
                   <button
                     type="button"
-                    className="max-w-36 padding-button rounded-lg bg-button text-button-text text-sm cursor-pointer hover:opacity-60 transition duration-300 ease-in"
+                    className="padding-button rounded-lg bg-button text-button-text text-sm cursor-pointer hover:opacity-60 transition duration-300 ease-in"
                   >
                     리뷰 작성하기
                   </button>
-                )
-              ) : (
-                !data?.isCompleted && (
-                  <button
-                    type="button"
-                    onClick={() => leaveGathering(Number(data?.id))}
-                    className="max-w-36 padding-button rounded-lg text-button border-1 border-button text-sm cursor-pointer hover:opacity-60 transition duration-300 ease-in"
-                  >
-                    참여 취소하기
-                  </button>
-                )
-              )}
-            </div>
+                )}
+              </div>
+            )}
+            {/* 참여 취소 */}
+            <button
+              type="button"
+              onClick={() => leaveGathering(Number(data?.id))}
+              className="padding-button rounded-lg text-button border-1 border-button text-sm hover:bg-white hover-button"
+            >
+              참여 취소하기
+            </button>
           </div>
         </div>
       ))}

--- a/src/components/mypage/LoadingUI.tsx
+++ b/src/components/mypage/LoadingUI.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+interface LoadingUIProps {
+    width: string;
+    height: string;
+}
+
+/**
+ * 마이페이지 모임 리스트 로딩 스켈레톤
+ * @prop {string} width w-full, w-[17.5rem] 등
+ * @prop {string} height h-32, h-[10rem] 등
+ */
+export default function LoadingUI({ width = 'w-full', height = 'h-32' }: LoadingUIProps) {
+    return (
+        <div className={`relative min-h-[100px] ${width} ${height} p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item animate-pulse`}>
+            {/* 좌측: 썸네일 및 뱃지 */}
+            <article className="relative">
+                {/* 상단 뱃지 */}
+                <div className="absolute top-3 left-3 z-10 bg-main-300 rounded-full px-3 py-1 flex justify-center items-center gap-2">
+                    <div className="w-6 h-6 bg-gray-300 rounded-full" />
+                    <div className="w-16 h-4 bg-gray-300 rounded" />
+                </div>
+                {/* 썸네일 이미지 */}
+                <div className="w-[17.5rem] h-[10rem] rounded-xl bg-gray-200 object-cover" />
+            </article>
+            {/* 우측: 정보 및 버튼 */}
+            <div className="flex flex-col justify-between flex-1 py-2">
+                {/* 모임 정보 */}
+                <div className="flex flex-col gap-2">
+                    <div className="flex items-center gap-2">
+                        <div className="w-16 h-5 bg-gray-300 rounded-full" />
+                        <div className="w-16 h-5 bg-gray-200 rounded-full" />
+                    </div>
+                    <div className="w-32 h-6 bg-gray-300 rounded" />
+                    <div className="w-24 h-4 bg-gray-200 rounded" />
+                    <div className="flex items-center gap-4 text-sm font-medium">
+                        <div className="flex items-center gap-1">
+                            <div className="w-4 h-4 bg-gray-300 rounded-full" />
+                            <div className="w-12 h-3 bg-gray-200 rounded" />
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                            <div className="w-16 h-3 bg-gray-200 rounded" />
+                            <div className="w-12 h-3 bg-gray-200 rounded" />
+                        </div>
+                    </div>
+                </div>
+                {/* 버튼 영역 */}
+                <div className="flex gap-2 mt-4">
+                    <div className="w-32 h-8 bg-gray-300 rounded-lg" />
+                    <div className="w-32 h-8 bg-gray-200 rounded-lg" />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/mypage/MyReviews.tsx
+++ b/src/components/mypage/MyReviews.tsx
@@ -27,11 +27,13 @@ export default function MyReviews({ teamId }: { teamId: string }) {
   const queryClient = useQueryClient();
   const gatherings = queryClient.getQueryData<JoinedGathering[]>(["joinedGatherings", token]) ?? [];
 
-  // 작성 가능한 리뷰: 마감 완료 && 개설 확정 (5명 이상) && 작성하지 않은 모임들
-  const reviewableGatherings = gatherings.filter((gathering: JoinedGathering) => !gathering.isReviewed && gathering.isCompleted && gathering.participantCount >= 5);
+  // 작성 가능한 모임: 개설 확정 (5명 이상) && 작성하지 않은 모임
+  const reviewableGatherings = gatherings.filter((gathering: JoinedGathering) => !gathering.isReviewed && gathering.participantCount >= 5);
 
-  // 작성한 리뷰
+  // 작성한 모임
   const reviewedGatherings = gatherings.filter((gathering: JoinedGathering) => gathering.isReviewed);
+
+  // 작성한 리뷰 (작성한 모임의 ID와 유저 ID를 통해 조회)
   const { data: createdReviews } = useFetchMyCreatedReviews(token!, reviewedGatherings.map(gathering => gathering.id), userId);
 
   return (
@@ -55,10 +57,9 @@ export default function MyReviews({ teamId }: { teamId: string }) {
       </div>
 
       {/* 리뷰 */}
-
       {tab === 0 ? (
         reviewableGatherings.length === 0 ?
-          <span className="flex h-[100px] w-full items-center justify-center text-gray-700">작성 가능한 리뷰가 없어요</span>
+          <span className="text-gray-500 text-center">작성 가능한 리뷰가 없어요</span>
           :
           <div className="flex flex-col gap-4">
             {reviewableGatherings.map((gathering: JoinedGathering) => (
@@ -114,7 +115,7 @@ export default function MyReviews({ teamId }: { teamId: string }) {
       ) :
         (
           createdReviews?.length === 0 ?
-            <span className="flex h-[100px] w-full items-center justify-center text-gray-700">아직 작성한 리뷰가 없어요</span>
+            <span className="text-gray-500 text-center">아직 작성한 리뷰가 없어요</span>
             :
             <div
               className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"

--- a/src/components/shared/ui/OverlayForDisabled.tsx
+++ b/src/components/shared/ui/OverlayForDisabled.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+interface OverlayForDisabledProps {
+    emoji?: React.ReactNode;
+    filterings: boolean
+    notice: string;
+    reason: string;
+}
+
+/** 모집 마감 / 모집 취소 모임 아이템에 씌울 오버레이
+ * @param emoji - lucide 아이콘
+ * @param filterings - 오버레이를 적용하는 조건
+ * @param notice - 주요 알림 문구
+ * @param reason - 마감 또는 취소된 근거
+ * @description 부모 아이템에 relative 속성 필요 
+ */
+export default function OverlayForDisabled({ emoji, filterings, notice, reason }: OverlayForDisabledProps) {
+    return (
+        <>
+            {filterings && (
+                <div className="absolute bg-black/90 inset-0 z-20 flex items-center justify-center text-center rounded-xl">
+                    <div className="px-4 py-2 rounded-lg flex flex-col gap-1 text-sm text-white items-center">
+                        <div className='flex items-center gap-1'>
+                            {emoji && <>{emoji}</>}
+                            <span>{notice}</span>
+                        </div>
+                        <span>{reason}</span>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}
+


### PR DESCRIPTION
## 📌 전역 모임 아이템 오버레이 구현
• OverlayForDisabled.tsx
• emoji, filterings, notice, reason를 props로 전달 받음
• 모임 찾기, 찜한 모임, 마이페이지 '참여중인 모임', '내가 만든 모임'의 아이템 위에 사용

## 📌 마이페이지 로딩 UI 구현
• src/components/mypage/LoadingUI.tsx
• '참여중인 모임', '내가 만든 모임'의 useQuery isLoading에 보여주는 UI

## 📌 참여중인 모임의 인디케이터 버튼 & 오버레이 조건 수정
• 마감 완료 및 5명 이상 모집 및 모임 후 '이용 완료' 표시
• 마감 미완료 및 모임 전 '이용 예정' 표시
• 마감 미완료 및 5명 이상 모집 '개설 확정' 표시
• 마감 미완료 및 5명 미만 시 '개설 대기' 표시
• 마감 완료 및 5명 미만 시 오버레이 