### PR TITLE
[refactor] serverFetcher 경로에 EXTERNAL_PATHS 참조, serverFetcher에 no-store 삭제, 마이페이지 로딩 UI 오버플로우 해결

### DIFF
--- a/src/app/gatherings/detail/[id]/page.tsx
+++ b/src/app/gatherings/detail/[id]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
-import { Reviews } from '@/types/reviews';
 import { serverFetcher } from '@/lib/api/serverFetcher';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { Gathering } from '@/types/gatherings';
+import { Reviews } from '@/types/reviews';
 import GatheringsDetailUI from '@/components/gatherings/detail/GatheringDetailUI';
 
 export interface PageProps {
@@ -25,13 +27,7 @@ export async function generateMetadata(
     let detail;
 
     try {
-        const response = await fetch(`${process.env.API_URI_DEV}/gatherings/${id}`, {
-            next: { revalidate: 60 },
-            headers: {
-                'Content-Type': 'application/json',
-            }
-        });
-        detail = await response.json();
+        detail = await serverFetcher<Gathering>(`${EXTERNAL_PATHS.fetchGatheringDetail(Number(id))}`, { next: { revalidate: 60 } });
     } catch (error) {
         console.error('모임 상세 페이지 메타데이터 생성 실패:', error);
         detail = null;

--- a/src/app/gatherings/page.tsx
+++ b/src/app/gatherings/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { serverFetcher } from '@/lib/api/serverFetcher';
 import { Gathering } from "@/types/gatherings";
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
 import Gatherings from "@/components/gatherings/Gatherings";
 
 export const metadata: Metadata = {
@@ -10,7 +11,7 @@ export const metadata: Metadata = {
 
 async function getInitialGatherings(): Promise<Gathering[]> {
     try {
-        const data = await serverFetcher(`/gatherings?limit=10&offset=0&type=DALLAEMFIT`, { next: { revalidate: 60 } });
+        const data = await serverFetcher(`${EXTERNAL_PATHS.GATHERINGS}?limit=10&offset=0&type=DALLAEMFIT`);
 
         if (Array.isArray(data)) {
             // DALLAEMFIT의 경우 클라이언트에서 필터링

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { serverFetcher } from '@/lib/api/serverFetcher';
+import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
 import { ReviewItem, Reviews } from "@/types/reviews";
 import ReviewsUI from "@/components/reviews/ReviewsUI";
 
@@ -10,9 +11,7 @@ export const metadata: Metadata = {
 
 async function getInitialReviews(): Promise<ReviewItem[]> {
     try {
-        const responseData = await serverFetcher<Reviews>(`/reviews?limit=3&offset=0&type=DALLAEMFIT&sortBy=createdAt&sortOrder=desc`, {
-            next: { revalidate: 60 }
-        });
+        const responseData = await serverFetcher<Reviews>(`${EXTERNAL_PATHS.REVIEWS}?limit=3&offset=0&type=DALLAEMFIT&sortBy=createdAt&sortOrder=desc`);
         // 페이지네이션된 응답에서 data 배열 추출
         const data = responseData?.data || [];
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
     title: `로그인 | Meet Meet`,
     description: `로그인 페이지 입니다.`,
 };
+
 export default function SignInPage() {
     return (
         <div className='w-full h-full py-20 flex flex-col lg:flex-row items-center justify-center gap-0 lg:gap-20'>

--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -17,7 +17,7 @@ export default function CreatedGatherings() {
 
   const { data: gatherings = [], isLoading, error } = useFetchCreatedGatherings(token!, userId);
 
-  if (isLoading) return <LoadingUI width="w-full" height="h-32" />;
+  if (isLoading) return <LoadingUI />;
   if (error) return <p className="text-center text-red-500">에러: {(error as Error).message}</p>;
   if (!isLoading && !error && gatherings.length === 0) return <p className="text-center text-gray-500">내가 만든 모임이 없어요</p>;
 

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -40,7 +40,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
     return a.isCompleted ? 1 : -1;
   });
 
-  if (isLoading) return <LoadingUI width="w-full" height="h-32" />;
+  if (isLoading) return <LoadingUI />;
   if (error) return <div className="text-red-500">에러: {error.message}</div>;
   if (gatherings.length === 0) return <div className="text-gray-500 text-center">참여한 모임이 없습니다</div>;
 

--- a/src/components/mypage/shared/ui/LoadingUI.tsx
+++ b/src/components/mypage/shared/ui/LoadingUI.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 interface LoadingUIProps {
-    width: string;
-    height: string;
+    width?: string;
 }
 
 /**
@@ -10,9 +9,9 @@ interface LoadingUIProps {
  * @prop {string} width w-full, w-[17.5rem] 등
  * @prop {string} height h-32, h-[10rem] 등
  */
-export default function LoadingUI({ width = 'w-full', height = 'h-32' }: LoadingUIProps) {
+export default function LoadingUI({ width = 'w-full' }: LoadingUIProps) {
     return (
-        <div className={`relative min-h-[100px] ${width} ${height} p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item animate-pulse`}>
+        <div className={`relative ${width} p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item animate-pulse`}>
             {/* 좌측: 썸네일 및 뱃지 */}
             <article className="relative">
                 {/* 상단 뱃지 */}

--- a/src/lib/api/serverFetcher.ts
+++ b/src/lib/api/serverFetcher.ts
@@ -5,7 +5,7 @@ export interface ServerFetcherOptions extends RequestInit {
 }
 
 /**
- * Server Side API Fetcher
+ * Server Side API Fetcher (SSG)
  * @param url 
  * @param options 
  * @returns Response JSON
@@ -17,12 +17,11 @@ export async function serverFetcher<T = unknown>(
     const defaultHeaders = { 'Content-Type': 'application/json' };
 
     const mergedOptions: RequestInit = {
-        ...options,
+        ...options, // revalidate, no-store, cache 등 옵션 설정
         headers: {
             ...defaultHeaders,
             ...(options?.headers || {}),
         },
-        cache: options?.cache || 'no-store',
     };
 
     const fullUrl = `${process.env.API_URI_DEV}${url}`;


### PR DESCRIPTION
## 📌 serverFetcher 경로에 EXTERNAL_PATHS 참조
• 하드코딩되어있던 경로 중 일부를 대체

## 📌 serverFetcher에 no-store 삭제
• 초기 데이터 로드 이후 나머지는 Client Side Fetching이므로 SSG로 기본 렌더링

## 📌 마이페이지 로딩 UI 오버플로우 해결