### PR TITLE
2 Commits: 마이페이지 모바일(sm) 반응형 리팩토링, 마이페이지 공통 컴포넌트 분리 및 가독성 개선을 위한 섹션 분리, DateReminder 분리

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,9 +9,9 @@ html {
 
 @theme {
   /* 브레이크 포인트 */
-  --breakpoint-sm: 375px;
-  --breakpoint-md: 744px;
-  --breakpoint-lg: 1100px;
+  --breakpoint-sm: 376px;
+  --breakpoint-md: 745px;
+  --breakpoint-lg: 1101px;
 
   /* 폰트 */
   --font-pretendard: var(--font-pretendard);
@@ -195,7 +195,7 @@ html {
 
   /* 페이지의 컨텐츠 컨테이너 */
   .contents-container {
-    @apply max-w-screen-lg min-h-screen h-full mx-auto px-4 md:px-20 pt-8 pb-10 flex flex-col gap-4 bg-neutral-50;
+    @apply max-w-screen-lg min-h-screen h-full mx-auto sm:px-4 md:px-20 pt-2 md:pt-8 pb-4 md:pb-10 flex flex-col gap-4 bg-neutral-50;
   }
 
   /* 버튼 padding */
@@ -215,7 +215,7 @@ html {
 
   /* 모달 배경 */
   .dialog-background {
-    @apply fixed inset-0 z-50 flex flex-col items-center justify-center gap-2 bg-black/40;
+    @apply fixed inset-0 z-50 px-4 sm:px-0 flex flex-col items-center justify-center gap-2 bg-black/40;
   }
 }
 

--- a/src/components/mypage/CreatableReview.tsx
+++ b/src/components/mypage/CreatableReview.tsx
@@ -1,0 +1,39 @@
+import { Gathering } from '@/types/gatherings';
+import dynamic from 'next/dynamic';
+import Image from 'next/image';
+
+const GatheringInformation = dynamic(() => import('@/components/mypage/shared/ui/GatheringInformation'), { ssr: false });
+const Button = dynamic(() => import('@/components/shared/ui/Button'), { ssr: false });
+
+/** 나의 리뷰 - 작성 가능한 리뷰 */
+export default function CreatableReview({ gathering, myReviewsTab, userId, onOpenReviewDialog }: { gathering: Gathering, myReviewsTab: number, userId: number, onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void }) {
+    return (
+        <div
+            key={gathering.id}
+            className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
+        >
+            {/* 이미지 */}
+            <div className="flex-shrink-0">
+                <Image
+                    src={gathering.image ?? ''}
+                    alt="모임 이미지"
+                    width={1000}
+                    height={1000}
+                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
+                />
+            </div>
+            {/* 정보 */}
+            <GatheringInformation data={gathering}>
+                {myReviewsTab === 0 && (
+                    <Button
+                        variant='default'
+                        text='리뷰 작성하기'
+                        onClick={() => onOpenReviewDialog({ userId, gatheringId: Number(gathering.id) })}
+                        customClassName='w-28 sm:w-32 text-xs sm:text-base'
+                    />
+                )}
+            </GatheringInformation>
+        </div>
+    );
+}
+

--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -29,7 +29,7 @@ export default function CreatedGatherings() {
           return (
             <div
               key={gathering.id}
-              className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
+              className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
             >
               <OverlayForDisabled
                 filterings={getTimeRemaining(gathering?.registrationEnd) === '마감됨' && gathering.participantCount < 5}
@@ -53,9 +53,9 @@ export default function CreatedGatherings() {
               </article>
 
               {/* 우측 정보 */}
-              <div className='flex flex-col justify-between'>
+              <article className='flex flex-col justify-between'>
                 <div className='flex flex-col gap-1'>
-                  <h3 className="text-xl font-semibold text-gray-800">{gathering.name}</h3>
+                  <h3 className="text-lg sm:text-xl font-semibold text-gray-800">{gathering.name}</h3>
                   <p className="text-gray-600">{gathering.location}</p>
                   <div className='flex items-center gap-4 text-sm font-medium'>
                     {/* 참여자 수 */}
@@ -74,7 +74,7 @@ export default function CreatedGatherings() {
                     </div>
                   </div>
                 </div>
-              </div>
+              </article>
             </div>
           );
         })}

--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -3,47 +3,40 @@
 import { useFetchCreatedGatherings } from '@/hooks/api/mypage/useFetchCreatedGatherings';
 import { useContext } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
-import { formatDate, formatTime, getTimeRemaining } from '@/components/shared/utils/dateFormats';
-import { UserRoundCheck } from "lucide-react"
+import { getTimeRemaining } from '@/components/shared/utils/dateFormats';
 import Image from 'next/image';
 import dynamic from 'next/dynamic';
 
 const LoadingUI = dynamic(() => import('@/components/mypage/shared/ui/LoadingUI'), { ssr: false });
-const OverlayForDisabled = dynamic(() => import('@/components/shared/ui/OverlayForDisabled'), { ssr: false });
+const GatheringInformation = dynamic(() => import('@/components/mypage/shared/ui/GatheringInformation'), { ssr: false });
+const DateReminder = dynamic(() => import('@/components/shared/ui/DateReminder'), { ssr: false });
 
-/** 마이페이지 내가 만든 모임 */
+/** 마이페이지 '내가 만든 모임' */
 export default function CreatedGatherings() {
   const { token, userId } = useContext(AuthContext);
 
-  const { data: gatherings = [], isLoading, error } = useFetchCreatedGatherings(token!, userId);
+  const { data: gatheringsRaw = [], isLoading, error } = useFetchCreatedGatherings(token!, userId);
+
+  const gatherings = gatheringsRaw.filter(gathering => {
+    return getTimeRemaining(gathering.registrationEnd) !== '마감됨';
+  });
 
   if (isLoading) return <LoadingUI />;
   if (error) return <p className="text-center text-red-500">에러: {(error as Error).message}</p>;
   if (!isLoading && !error && gatherings.length === 0) return <p className="text-center text-gray-500">내가 만든 모임이 없어요</p>;
 
   return (
-    <div className='px-4 flex flex-col gap-2'>
+    <section className='px-4 flex flex-col gap-2'>
       <div className="flex w-full flex-col gap-4">
-
         {!isLoading && !error && gatherings.map(gathering => {
           return (
             <div
               key={gathering.id}
               className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
             >
-              <OverlayForDisabled
-                filterings={getTimeRemaining(gathering?.registrationEnd) === '마감됨' && gathering.participantCount < 5}
-                notice="마감되었습니다"
-                reason="(모집 마감)"
-              />
-              {/* 좌측 */}
+              {/* 좌측 이미지 */}
               <article className='relative'>
-                <div className="relative px-3 bg-white/80 rounded-full flex items-center text-xs">
-                  <div className="absolute top-3 left-3 bg-main-600 rounded-full px-3 py-1 flex justify-center items-center gap-2 z-10">
-                    <Image src={"/icons/Alarm.svg"} alt="시간" width={24} height={24} />
-                    <span className="font-medium text-white">{getTimeRemaining(gathering?.registrationEnd || '')}</span>
-                  </div>
-                </div>
+                <DateReminder registrationEnd={gathering?.registrationEnd} />
                 <Image src={gathering?.image}
                   alt='모임 이미지'
                   width={1000}
@@ -54,31 +47,12 @@ export default function CreatedGatherings() {
 
               {/* 우측 정보 */}
               <article className='flex flex-col justify-between'>
-                <div className='flex flex-col gap-1'>
-                  <h3 className="text-lg sm:text-xl font-semibold text-gray-800">{gathering.name}</h3>
-                  <p className="text-gray-600">{gathering.location}</p>
-                  <div className='flex items-center gap-4 text-sm font-medium'>
-                    {/* 참여자 수 */}
-                    <div className='flex items-center gap-1'>
-                      <UserRoundCheck className={`w-4 h-4 text-main-500`} />
-                      <span>{gathering.participantCount}/{gathering.capacity}</span>
-                    </div>
-                    {/* 날짜/시간 */}
-                    <div className="flex flex-wrap gap-2">
-                      <span className={`inline-flex items-center rounded-md`}>
-                        {formatDate(gathering.dateTime)}
-                      </span>
-                      <span className={`inline-flex items-center rounded-md`}>
-                        {formatTime(gathering.dateTime)}
-                      </span>
-                    </div>
-                  </div>
-                </div>
+                <GatheringInformation data={gathering} />
               </article>
             </div>
           );
         })}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/mypage/CreatedReview.tsx
+++ b/src/components/mypage/CreatedReview.tsx
@@ -1,0 +1,39 @@
+import { ReviewItem } from '@/types/reviews';
+import { formatDate, formatTime } from '@/components/shared/utils/dateFormats';
+import { Heart } from 'lucide-react';
+import Image from 'next/image';
+
+/** 나의 리뷰 - 작성한 리뷰 */
+export default function CreatedReview({ review }: { review: ReviewItem }) {
+    return (
+        <section className='flex flex-col sm:flex-row gap-4'>
+            <div className="flex-shrink-0">
+                <Image
+                    src={review?.Gathering?.image ?? ''}
+                    alt="모임 이미지"
+                    width={1000}
+                    height={1000}
+                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
+                />
+            </div>
+            <div className="flex flex-col gap-1">
+                <div className='flex items-center gap-1'>
+                    {Array.from({ length: review?.score }).map((_, index) => (
+                        <Heart key={index} className="w-4 h-4 text-main-500 fill-main-500" />
+                    ))}
+                </div>
+                <p className='text-sm sm:text-base'>{review?.comment}</p>
+                <span className="text-sm sm:text-xl font-semibold">{review?.Gathering?.name}</span>
+                <div className="flex flex-wrap gap-2 text-xs sm:text-base text-gray-400">
+                    <span className={`inline-flex items-center rounded-md`}>
+                        {formatDate(review?.Gathering?.dateTime ?? '')}
+                    </span>
+                    <span className={`inline-flex items-center rounded-md`}>
+                        {formatTime(review?.Gathering?.dateTime ?? '')}
+                    </span>
+                </div>
+            </div>
+        </section>
+    );
+}
+

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -49,7 +49,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
       {sortedGatherings.map(data => (
         <div
           key={data.id}
-          className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
+          className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
         >
           {/* 마감 완료 및 5명 미만 */}
           <OverlayForDisabled
@@ -75,9 +75,9 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
           </article>
 
           {/* 우측 */}
-          <div className='flex flex-col justify-between'>
+          <div className='flex flex-col gap-2 sm:gap-0 justify-between'>
             {/* 모임 정보 */}
-            <div className='flex flex-col gap-1'>
+            <div className='flex flex-col gap-2 sm:gap-1'>
               <div className='flex items-center gap-1'>
                 {/* 마감 완료 및 5명 이상 모집 및 모임 후 '이용 완료' */}
                 {getTimeRemaining(data?.registrationEnd) === '마감됨' && data?.participantCount >= 5 && data?.isCompleted && (
@@ -99,8 +99,10 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                   <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">개설 대기</div>
                 )}
               </div>
-              <h1 className="text-xl font-semibold">{data?.name}</h1>
-              <p className="text-gray-600">{data?.location}</p>
+              <div className='flex items-center sm:items-start sm:flex-col gap-2 sm:gap-1'>
+                <h1 className="text-lg sm:text-xl font-semibold">{data?.name}</h1>
+                <p className="text-sm sm:text-base text-gray-600">{data?.location}</p>
+              </div>
               <div className='flex items-center gap-4 text-sm font-medium'>
                 {/* 참여자 수 */}
                 <div className='flex items-center gap-1'>
@@ -119,7 +121,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
               </div>
             </div>
 
-            <div className='flex gap-2'>
+            <div className='flex text-xs sm:text-base gap-2'>
               {/* 개설 확정 모임은 참여 상태라면 리뷰 작성이 가능*/}
               {data?.participantCount >= 5 && (
                 <div>
@@ -131,14 +133,14 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                         setSelectedTab(1);
                         setMyReviewsTab(1);
                       }}
-                      customClassName='w-36'
+                      customClassName='w-24 sm:w-36'
                     />
                   ) : (
                     <Button
                       variant='default'
                       text='리뷰 작성하기'
                       onClick={() => onOpenReviewDialog({ userId, gatheringId: Number(data.id) })}
-                      customClassName='w-32'
+                      customClassName='w-28 sm:w-32'
                     />
                   )}
                 </div>
@@ -148,7 +150,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                 variant='cancel'
                 text='참여 취소하기'
                 onClick={() => leaveGathering(Number(data?.id))}
-                customClassName='w-32'
+                customClassName='w-28 sm:w-32'
               />
             </div>
 

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -4,8 +4,8 @@ import { useFetchJoinedGatherings } from '@/hooks/api/mypage/useFetchJoinedGathe
 import { useLeaveGathering } from '@/hooks/api/gatherings/detail/useLeaveGathering';
 import { useContext, useState } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
-import { formatDate, formatTime, getTimeRemaining } from '@/components/shared/utils/dateFormats';
-import { UserRoundCheck, CheckCircle } from "lucide-react"
+import { getTimeRemaining } from '@/components/shared/utils/dateFormats';
+import { CheckCircle } from "lucide-react"
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 
@@ -13,9 +13,17 @@ const LoadingUI = dynamic(() => import('@/components/mypage/shared/ui/LoadingUI'
 const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 const OverlayForDisabled = dynamic(() => import('@/components/shared/ui/OverlayForDisabled'), { ssr: false });
 const Button = dynamic(() => import('@/components/shared/ui/Button'), { ssr: false });
+const GatheringInformation = dynamic(() => import('@/components/mypage/shared/ui/GatheringInformation'), { ssr: false });
+const DateReminder = dynamic(() => import('@/components/shared/ui/DateReminder'), { ssr: false });
 
-/** 마이페이지 참여중인 모임 */
-export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOpenReviewDialog }: { setSelectedTab: (tab: number) => void, setMyReviewsTab: (tab: number) => void, onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void }) {
+interface JoinedGatheringsProps {
+  setSelectedTab: (tab: number) => void;
+  setMyReviewsTab: (tab: number) => void;
+  onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void;
+}
+
+/** 마이페이지 '참여중인 모임' */
+export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOpenReviewDialog }: JoinedGatheringsProps) {
   const { token, userId } = useContext(AuthContext);
 
   const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
@@ -45,7 +53,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
   if (gatherings.length === 0) return <div className="text-gray-500 text-center">참여한 모임이 없습니다</div>;
 
   return (
-    <div className='px-4 flex flex-col gap-2'>
+    <section className='px-4 flex flex-col gap-2'>
       {sortedGatherings.map(data => (
         <div
           key={data.id}
@@ -60,12 +68,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
 
           {/* 좌측 */}
           <article className='relative'>
-            <div className="relative px-3 bg-white/80 rounded-full flex items-center text-xs">
-              <div className="absolute top-3 left-3 z-10 bg-main-600 rounded-full px-3 py-1 flex justify-center items-center gap-2">
-                <Image src={"/icons/Alarm.svg"} alt="시간" width={24} height={24} />
-                <span className="font-medium text-white">{getTimeRemaining(data?.registrationEnd || '')}</span>
-              </div>
-            </div>
+            <DateReminder registrationEnd={data?.registrationEnd} />
             <Image src={data?.image}
               alt='모임 이미지'
               width={1000}
@@ -81,50 +84,31 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
               <div className='flex items-center gap-1'>
                 {/* 마감 완료 및 5명 이상 모집 및 모임 후 '이용 완료' */}
                 {getTimeRemaining(data?.registrationEnd) === '마감됨' && data?.participantCount >= 5 && data?.isCompleted && (
-                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">이용 완료</div>
-                )}
+                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">이용 완료</div>)}
+
                 {/* 마감 미완료 및 모임 전 '이용 예정' */}
                 {getTimeRemaining(data?.registrationEnd) !== '마감됨' && !data?.isCompleted && (
-                  <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs">이용 예정</div>
-                )}
+                  <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs">이용 예정</div>)}
+
                 {/* 마감 미완료 및 5명 이상 모집 '개설 확정'  */}
                 {getTimeRemaining(data?.registrationEnd) !== '마감됨' && data?.participantCount >= 5 && (
                   <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs flex items-center gap-1">
                     <CheckCircle className="w-4 h-4 text-white" />
                     개설 확정
-                  </div>
-                )}
+                  </div>)}
+
                 {/* 마감 미완료 및 5명 미만 시 '개설 대기' */}
                 {getTimeRemaining(data?.registrationEnd) !== '마감됨' && data?.participantCount < 5 && (
-                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">개설 대기</div>
-                )}
+                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">개설 대기</div>)}
               </div>
-              <div className='flex items-center sm:items-start sm:flex-col gap-2 sm:gap-1'>
-                <h1 className="text-lg sm:text-xl font-semibold">{data?.name}</h1>
-                <p className="text-sm sm:text-base text-gray-600">{data?.location}</p>
-              </div>
-              <div className='flex items-center gap-4 text-sm font-medium'>
-                {/* 참여자 수 */}
-                <div className='flex items-center gap-1'>
-                  <UserRoundCheck className="w-4 h-4 text-main-500" />
-                  <span>{data?.participantCount ?? '-'}/{data?.capacity ?? '-'}</span>
-                </div>
-                {/* 날짜 */}
-                <div className="flex flex-wrap gap-2">
-                  <span className={`inline-flex items-center rounded-md`}>
-                    {formatDate(data?.dateTime ?? '')}
-                  </span>
-                  <span className={`inline-flex items-center rounded-md`}>
-                    {formatTime(data?.dateTime ?? '')}
-                  </span>
-                </div>
-              </div>
+              <GatheringInformation data={data} />
             </div>
 
             <div className='flex text-xs sm:text-base gap-2'>
-              {/* 개설 확정 모임은 참여 상태라면 리뷰 작성이 가능*/}
+              {/* 개설 확정 모임이여야 리뷰 관련 버튼 표시*/}
               {data?.participantCount >= 5 && (
                 <div>
+                  {/* 리뷰 작성 완료 */}
                   {data.isReviewed ? (
                     <Button
                       variant='default'
@@ -136,6 +120,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                       customClassName='w-24 sm:w-36'
                     />
                   ) : (
+                    // 리뷰 작성 미완료 
                     <Button
                       variant='default'
                       text='리뷰 작성하기'
@@ -145,7 +130,8 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                   )}
                 </div>
               )}
-              {/* 참여 취소 */}
+
+              {/* 참여 취소 버튼 */}
               <Button
                 variant='cancel'
                 text='참여 취소하기'
@@ -153,7 +139,6 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                 customClassName='w-28 sm:w-32'
               />
             </div>
-
           </div>
         </div>
       ))}
@@ -163,6 +148,6 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
         text={errorMessage}
         onClose={() => setIsErrorDialogOpen(false)}
       />
-    </div>
+    </section>
   );
 }

--- a/src/components/mypage/MyPageUI.tsx
+++ b/src/components/mypage/MyPageUI.tsx
@@ -17,15 +17,15 @@ export default function MyPageUI() {
 
   return (
     <main className="contents-container">
-      <div className="pt-10 px-6 flex flex-col gap-4">
+      <section className="pt-10 px-6 flex flex-col gap-4">
         <h1 className="text-2xl font-bold text-gray-700">마이 페이지</h1>
 
         {/* 프로필 카드 */}
         <ProfileCard />
 
-        {/* 탭 네비게이션 */}
-        <div className=" border-t-[3px] border-gray-800">
-          <div className="sm:px-4 py-4 flex gap-4 justify-between sm:justify-start text-sm sm:text-lg font-bold">
+        <section className=" border-t-[3px] border-gray-800">
+          {/* 탭 네비게이션 */}
+          <section className="sm:px-4 py-4 flex gap-4 justify-between sm:justify-start text-sm sm:text-lg font-bold">
             {[
               { label: "참여중인 모임", value: 0 },
               { label: "나의 리뷰", value: 1 },
@@ -44,7 +44,7 @@ export default function MyPageUI() {
                 {label}
               </button>
             ))}
-          </div>
+          </section>
 
           {selectedTab === 0 &&
             <JoinedGatherings
@@ -60,8 +60,8 @@ export default function MyPageUI() {
               onOpenReviewDialog={setReviewableGathering}
             />}
           {selectedTab === 2 && <CreatedGatherings />}
-        </div>
-      </div>
+        </section>
+      </section>
 
       {reviewableGathering && (
         <CreateReviewDialog

--- a/src/components/mypage/MyPageUI.tsx
+++ b/src/components/mypage/MyPageUI.tsx
@@ -25,7 +25,7 @@ export default function MyPageUI() {
 
         {/* 탭 네비게이션 */}
         <div className=" border-t-[3px] border-gray-800">
-          <div className="px-4 py-4 flex gap-4 text-lg font-bold">
+          <div className="sm:px-4 py-4 flex gap-4 justify-between sm:justify-start text-sm sm:text-lg font-bold">
             {[
               { label: "참여중인 모임", value: 0 },
               { label: "나의 리뷰", value: 1 },

--- a/src/components/mypage/MyReviews.tsx
+++ b/src/components/mypage/MyReviews.tsx
@@ -3,18 +3,23 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useContext } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
-import { formatDate, formatTime } from '@/components/shared/utils/dateFormats';
 import { useFetchMyCreatedReviews } from '@/hooks/api/mypage/useFetchMyCreatedReviews';
 import { JoinedGathering } from '@/types/gatherings';
 import { ReviewItem } from '@/types/reviews';
-import { Heart, UserRoundCheck } from 'lucide-react';
-import Image from 'next/image';
 import dynamic from 'next/dynamic';
 
 const Button = dynamic(() => import('@/components/shared/ui/Button'), { ssr: false });
+const CreatableReview = dynamic(() => import('@/components/mypage/CreatableReview'), { ssr: false });
+const CreatedReview = dynamic(() => import('@/components/mypage/CreatedReview'), { ssr: false });
 
-/** 마이페이지 나의 리뷰 */
-export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewDialog }: { myReviewsTab: number, setMyReviewsTab: (tab: number) => void, onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void }) {
+interface MyReviewsProps {
+  myReviewsTab: number;
+  setMyReviewsTab: (tab: number) => void;
+  onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void;
+}
+
+/** 마이페이지 '나의 리뷰' */
+export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewDialog }: MyReviewsProps) {
   const { token, userId } = useContext(AuthContext);
 
   const queryClient = useQueryClient();
@@ -30,23 +35,21 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
   const { data: createdReviews } = useFetchMyCreatedReviews(token!, reviewedGatherings.map(gathering => gathering.id), userId);
 
   return (
-    <div className="px-4 flex w-full flex-col justify-start gap-5">
+    <section className="px-4 flex w-full flex-col justify-start gap-5">
       <div className="flex justify-center sm:justify-start items-center gap-2">
         {/* 작성 가능한 리뷰, 작성한 리뷰 버튼 */}
-        <button
-          type="button"
+        <Button
+          variant='default'
+          text='작성 가능한 리뷰'
           onClick={() => setMyReviewsTab(0)}
-          className={`rounded-lg px-4 py-2 text-sm transition-colors ${myReviewsTab === 0 ? 'bg-gray-700 text-white' : 'bg-gray-100 text-gray-700'} cursor-pointer`}
-        >
-          작성 가능한 리뷰
-        </button>
-        <button
-          type="button"
+          customClassName={`rounded-lg px-4 py-2 text-sm ${myReviewsTab === 0 ? 'bg-gray-700 text-white' : 'bg-gray-100 text-gray-700'} hover:text-white`}
+        />
+        <Button
+          variant='default'
+          text='작성한 리뷰'
           onClick={() => setMyReviewsTab(1)}
-          className={`rounded-lg px-4 py-2 text-sm transition-colors ${myReviewsTab === 1 ? 'bg-gray-700 text-white' : 'bg-gray-100 text-gray-700'} cursor-pointer`}
-        >
-          작성한 리뷰
-        </button>
+          customClassName={`rounded-lg px-4 py-2 text-sm ${myReviewsTab === 1 ? 'bg-gray-700 text-white' : 'bg-gray-100 text-gray-700'} hover:text-white`}
+        />
       </div>
 
       {/* 리뷰 */}
@@ -56,52 +59,13 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
           :
           <div className="flex flex-col gap-4">
             {reviewableGatherings.map((gathering: JoinedGathering) => (
-              <div
+              <CreatableReview
                 key={gathering.id}
-                className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
-              >
-                {/* 이미지 */}
-                <div className="flex-shrink-0">
-                  <Image
-                    src={gathering.image ?? ''}
-                    alt="모임 이미지"
-                    width={1000}
-                    height={1000}
-                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
-                  />
-                </div>
-                {/* 정보 + 버튼 */}
-                <div className="flex flex-col gap-2 sm:gap-0 justify-between">
-                  {/* 정보 */}
-                  <div className='flex flex-col gap-1'>
-                    <h1 className="text-lg sm:text-xl font-semibold">{gathering.name}</h1>
-                    <p className="text-gray-600">{gathering?.location}</p>
-                    <div className='flex items-center gap-4 text-sm font-medium'>
-                      <div className='flex items-center gap-1'>
-                        <UserRoundCheck className="w-4 h-4 text-main-500" />
-                        <span>{gathering.participantCount ?? '-'}/{gathering.capacity ?? '-'}</span>
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        <span className={`inline-flex items-center rounded-md`}>
-                          {formatDate(gathering?.dateTime ?? '')}
-                        </span>
-                        <span className={`inline-flex items-center rounded-md`}>
-                          {formatTime(gathering?.dateTime ?? '')}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  {/* 버튼 */}
-                  {myReviewsTab === 0 && (
-                    <Button
-                      variant='default'
-                      text='리뷰 작성하기'
-                      onClick={() => onOpenReviewDialog({ userId, gatheringId: Number(gathering.id) })}
-                      customClassName='w-28 sm:w-32 text-sm'
-                    />
-                  )}
-                </div>
-              </div>
+                gathering={gathering}
+                myReviewsTab={myReviewsTab}
+                userId={userId}
+                onOpenReviewDialog={onOpenReviewDialog}
+              />
             ))}
           </div>
       ) :
@@ -113,39 +77,11 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
               className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
             >
               {createdReviews?.map((review: ReviewItem) => (
-                <div key={`${review?.Gathering?.id}-${review?.id}`} className='flex flex-col sm:flex-row gap-4'>
-                  {/* 이미지 */}
-                  <div className="flex-shrink-0">
-                    <Image
-                      src={review?.Gathering?.image ?? ''}
-                      alt="모임 이미지"
-                      width={1000}
-                      height={1000}
-                      className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1">
-                    <div className='flex items-center gap-1'>
-                      {Array.from({ length: review?.score }).map((_, index) => (
-                        <Heart key={index} className="w-4 h-4 text-main-500 fill-main-500" />
-                      ))}
-                    </div>
-                    <p className='text-sm sm:text-base'>{review?.comment}</p>
-                    <span className="text-sm sm:text-xl font-semibold">{review?.Gathering?.name}</span>
-                    <div className="flex flex-wrap gap-2 text-xs sm:text-base text-gray-400">
-                      <span className={`inline-flex items-center rounded-md`}>
-                        {formatDate(review?.Gathering?.dateTime ?? '')}
-                      </span>
-                      <span className={`inline-flex items-center rounded-md`}>
-                        {formatTime(review?.Gathering?.dateTime ?? '')}
-                      </span>
-                    </div>
-                  </div>
-                </div>
+                <div key={`${review?.Gathering?.id}-${review?.id}`}><CreatedReview review={review} /></div>
               ))}
             </div>
         )
       }
-    </div >
+    </section >
   );
 }

--- a/src/components/mypage/MyReviews.tsx
+++ b/src/components/mypage/MyReviews.tsx
@@ -31,7 +31,7 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
 
   return (
     <div className="px-4 flex w-full flex-col justify-start gap-5">
-      <div className="flex items-center gap-2">
+      <div className="flex justify-center sm:justify-start items-center gap-2">
         {/* 작성 가능한 리뷰, 작성한 리뷰 버튼 */}
         <button
           type="button"
@@ -51,14 +51,14 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
 
       {/* 리뷰 */}
       {myReviewsTab === 0 ? (
-        reviewableGatherings.length === 0 ?
+        !reviewableGatherings || reviewableGatherings.length === 0 ?
           <span className="text-gray-500 text-center">작성 가능한 리뷰가 없어요</span>
           :
           <div className="flex flex-col gap-4">
             {reviewableGatherings.map((gathering: JoinedGathering) => (
               <div
                 key={gathering.id}
-                className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
+                className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
               >
                 {/* 이미지 */}
                 <div className="flex-shrink-0">
@@ -71,10 +71,10 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
                   />
                 </div>
                 {/* 정보 + 버튼 */}
-                <div className="flex flex-col justify-between">
+                <div className="flex flex-col gap-2 sm:gap-0 justify-between">
                   {/* 정보 */}
                   <div className='flex flex-col gap-1'>
-                    <h1 className="text-xl font-semibold">{gathering.name}</h1>
+                    <h1 className="text-lg sm:text-xl font-semibold">{gathering.name}</h1>
                     <p className="text-gray-600">{gathering?.location}</p>
                     <div className='flex items-center gap-4 text-sm font-medium'>
                       <div className='flex items-center gap-1'>
@@ -97,7 +97,7 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
                       variant='default'
                       text='리뷰 작성하기'
                       onClick={() => onOpenReviewDialog({ userId, gatheringId: Number(gathering.id) })}
-                      customClassName='w-32'
+                      customClassName='w-28 sm:w-32 text-sm'
                     />
                   )}
                 </div>
@@ -106,14 +106,14 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
           </div>
       ) :
         (
-          createdReviews?.length === 0 ?
+          !createdReviews || createdReviews?.length === 0 ?
             <span className="text-gray-500 text-center">아직 작성한 리뷰가 없어요</span>
             :
             <div
-              className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
+              className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
             >
               {createdReviews?.map((review: ReviewItem) => (
-                <div key={`${review?.Gathering?.id}-${review?.id}`} className='flex gap-4'>
+                <div key={`${review?.Gathering?.id}-${review?.id}`} className='flex flex-col sm:flex-row gap-4'>
                   {/* 이미지 */}
                   <div className="flex-shrink-0">
                     <Image
@@ -130,12 +130,9 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
                         <Heart key={index} className="w-4 h-4 text-main-500 fill-main-500" />
                       ))}
                     </div>
-                    <p>{review?.comment}</p>
-                    <div className='flex gap-1 items-center'>
-                      <h1 className="text-xl font-semibold">{review?.Gathering?.name}</h1>
-                      <p className="text-gray-600">{review?.Gathering?.location}</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
+                    <p className='text-sm sm:text-base'>{review?.comment}</p>
+                    <span className="text-sm sm:text-xl font-semibold">{review?.Gathering?.name}</span>
+                    <div className="flex flex-wrap gap-2 text-xs sm:text-base text-gray-400">
                       <span className={`inline-flex items-center rounded-md`}>
                         {formatDate(review?.Gathering?.dateTime ?? '')}
                       </span>

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -17,7 +17,7 @@ export default function ProfileCard() {
     <section className="overflow-hidden border-2 border-gray-200 rounded-lg">
       {/* 배경 헤더 */}
       <section className="bg-main-350 relative px-4 py-6">
-        <div className="mb-1 text-lg font-bold text-white">내 프로필</div>
+        <div className="mb-1 text-sm sm:text-base md:text-lg font-bold text-white">내 프로필</div>
         <div className="absolute top-4 right-4">
           <button type="button" onClick={() => setIsProfileEditDialogOpen(true)} className='rounded-full hover-button'>
             <Image
@@ -25,7 +25,7 @@ export default function ProfileCard() {
               alt="프로필 수정"
               width={36}
               height={36}
-              className="pointer-events-none"
+              className="pointer-events-none size-8 sm:size-10"
             />
           </button>
         </div>
@@ -34,23 +34,23 @@ export default function ProfileCard() {
       {/* 프로필 정보 */}
       <section className="h-full flex items-center gap-4 bg-white p-4">
         {/* 이미지 */}
-        <div className="w-16 h-16 z-1 -mt-20 rounded-full border border-gray-400">
+        <div className="size-12 sm:size-24 z-1 -mt-20 rounded-full border border-gray-400">
           <Image
             src={userImage || '/icons/default_profile_image.svg'}
             alt="프로필"
             width={1000}
             height={1000}
-            className="w-full h-full border-gray-400 rounded-full pointer-events-none"
+            className="size-12 sm:size-full border-gray-400 rounded-full pointer-events-none"
           />
         </div>
         {/* 스펙 */}
         <div>
-          <div className="text-md font-bold text-main-500">{userName}</div>
+          <div className="text-sm sm:text-md font-bold text-main-500">{userName}</div>
           <div className="flex gap-2 text-sm text-gray-800">
-            <div className="font-bold">COMPANY</div>
-            <div>{userCompanyName}</div>
+            <div className="text-xs sm:text-base font-bold">COMPANY</div>
+            <div className='text-xs sm:text-base'>{userCompanyName}</div>
           </div>
-          <div className="flex gap-2 text-sm text-gray-800">
+          <div className="flex gap-2 text-gray-800 text-xs sm:text-sm">
             <div className="font-bold">E-MAIL</div>
             <div>{userEmail}</div>
           </div>

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -34,7 +34,7 @@ export default function ProfileCard() {
       {/* 프로필 정보 */}
       <section className="h-full flex items-center gap-4 bg-white p-4">
         {/* 이미지 */}
-        <div className="size-12 sm:size-24 z-1 -mt-20 rounded-full border border-gray-400">
+        <div className="size-12 sm:size-18 z-1 -mt-20 rounded-full border border-gray-400">
           <Image
             src={userImage || '/icons/default_profile_image.svg'}
             alt="프로필"
@@ -50,7 +50,7 @@ export default function ProfileCard() {
             <div className="text-xs sm:text-base font-bold">COMPANY</div>
             <div className='text-xs sm:text-base'>{userCompanyName}</div>
           </div>
-          <div className="flex gap-2 text-gray-800 text-xs sm:text-sm">
+          <div className="flex gap-2 text-gray-800 text-xs sm:text-base">
             <div className="font-bold">E-MAIL</div>
             <div>{userEmail}</div>
           </div>

--- a/src/components/mypage/ProfileEditDialog.tsx
+++ b/src/components/mypage/ProfileEditDialog.tsx
@@ -7,6 +7,7 @@ import { Upload } from 'lucide-react';
 import axios from 'axios';
 import dynamic from 'next/dynamic';
 
+const Button = dynamic(() => import('@/components/shared/ui/Button'), { ssr: false });
 const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
 
 const editProfile = async (imageFile: File | null, companyName: string, token: string) => {
@@ -93,7 +94,7 @@ export default function ProfileEditDialog({ setIsProfileEditDialogOpen }: { setI
     }
 
     return (
-        <div className="dialog-background">
+        <section className="dialog-background">
             <h1 className='text-2xl font-semibold text-white'>PROFILE EDIT</h1>
             <form
                 className="w-full max-w-md p-6 rounded-md bg-white shadow-md flex flex-col gap-4"
@@ -101,13 +102,13 @@ export default function ProfileEditDialog({ setIsProfileEditDialogOpen }: { setI
                 <div className="grid grid-cols-3 items-center gap-y-6 gap-x-4 w-full mb-2">
                     <label className="col-span-1 text-left font-semibold">IMAGE</label>
                     <div className="col-span-2 flex items-center gap-4">
-                        <button
-                            type="button"
-                            className="w-10 h-10 cursor-pointer"
+                        <Button
+                            variant='cancel'
                             onClick={handleFileClick}
+                            customClassName='size-16'
                         >
                             <Upload className='w-full h-full' />
-                        </button>
+                        </Button>
                         <input
                             type="file"
                             ref={fileInputRef}
@@ -127,16 +128,18 @@ export default function ProfileEditDialog({ setIsProfileEditDialogOpen }: { setI
                 </div>
                 {error && <p className="text-red-500 text-sm">{error}</p>}
                 <div className='flex gap-4'>
-                    <button
-                        type="button"
+                    <Button
+                        variant='default'
+                        text='취소'
                         onClick={handleCancel}
-                        className="w-full padding-button hover-button rounded-lg bg-button-categories text-button-text font-semibold">
-                        취소
-                    </button>
-                    <button type="submit"
-                        className="w-full padding-button hover-button rounded-lg bg-button  text-button-text font-semibold">
-                        수정하기
-                    </button>
+                        customClassName='w-full padding-button hover-button rounded-lg bg-button-categories text-button-text font-semibold'
+                    />
+                    <Button
+                        variant='default'
+                        text='수정하기'
+                        type='submit'
+                        customClassName='w-full padding-button hover-button rounded-lg bg-button text-button-text font-semibold'
+                    />
                 </div>
             </form>
             <ConfirmDialog
@@ -145,6 +148,6 @@ export default function ProfileEditDialog({ setIsProfileEditDialogOpen }: { setI
                 onClose={() => setConfirmDialog({ isOpen: false, text: '' })}
                 onConfirm={confirmDialog.onConfirm}
             />
-        </div>
+        </section>
     );
 }

--- a/src/components/mypage/ProfileEditDialog.tsx
+++ b/src/components/mypage/ProfileEditDialog.tsx
@@ -93,7 +93,7 @@ export default function ProfileEditDialog({ setIsProfileEditDialogOpen }: { setI
     }
 
     return (
-        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-2 bg-black/50">
+        <div className="dialog-background">
             <h1 className='text-2xl font-semibold text-white'>PROFILE EDIT</h1>
             <form
                 className="w-full max-w-md p-6 rounded-md bg-white shadow-md flex flex-col gap-4"

--- a/src/components/mypage/shared/ui/GatheringInformation.tsx
+++ b/src/components/mypage/shared/ui/GatheringInformation.tsx
@@ -1,0 +1,34 @@
+import { formatDate, formatTime } from "@/components/shared/utils/dateFormats";
+import { Gathering } from '@/types/gatherings';
+import { UserRoundCheck } from "lucide-react";
+
+export default function GatheringInformation({ data, children }: { data: Gathering, children?: React.ReactNode }) {
+    return (
+        <div className='flex flex-col gap-2 sm:gap-1 justify-between'>
+            <div className='flex flex-col gap-2 sm:gap-1'>
+                {/* 모임 이름  */}
+                <span className="text-lg sm:text-xl font-semibold">{data?.name}</span>
+                {/* 장소  */}
+                <span className="text-sm sm:text-base text-gray-600">{data?.location}</span>
+            </div>
+            <div className='flex items-center gap-4 text-sm font-medium'>
+                {/* 참여자 수 */}
+                <div className='flex items-center gap-1'>
+                    <UserRoundCheck className="w-4 h-4 text-main-500" />
+                    <span>{data?.participantCount ?? '-'}/{data?.capacity ?? '-'}</span>
+                </div>
+                {/* 날짜 */}
+                <div className="flex flex-wrap gap-2">
+                    <span className={`inline-flex items-center rounded-md`}>
+                        {formatDate(data?.dateTime ?? '')}
+                    </span>
+                    <span className={`inline-flex items-center rounded-md`}>
+                        {formatTime(data?.dateTime ?? '')}
+                    </span>
+                </div>
+            </div>
+            {children}
+        </div>
+    );
+}
+

--- a/src/components/mypage/shared/ui/LoadingUI.tsx
+++ b/src/components/mypage/shared/ui/LoadingUI.tsx
@@ -11,7 +11,7 @@ interface LoadingUIProps {
  */
 export default function LoadingUI({ width = 'w-full' }: LoadingUIProps) {
     return (
-        <div className={`relative ${width} p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item animate-pulse`}>
+        <div className={`relative ${width} p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item animate-pulse`}>
             {/* 좌측: 썸네일 및 뱃지 */}
             <article className="relative">
                 {/* 상단 뱃지 */}

--- a/src/components/shared/ui/Button.tsx
+++ b/src/components/shared/ui/Button.tsx
@@ -6,13 +6,21 @@ type ButtonVariant = 'default' | 'cancel' | 'disabled';
 
 interface ButtonProps {
     type?: 'button' | 'submit';
-    text: string;
+    text?: string;
     variant?: ButtonVariant;
     disabled?: boolean;
     customClassName?: string;
     onClick?: () => void | Promise<void>;
+    children?: React.ReactNode;
 }
 
+/**
+ * 프로젝트 공통 버튼 - 모임 만들기, 모임 상세, 마이페이지, 로그인, 회원가입...
+ * @param type 버튼 타입
+ * @param text 버튼 텍스트
+ * @param variant 버튼 변형
+ * @param disabled 버튼 비활성화 여부
+ */
 export default function Button({
     type = 'button',
     text,
@@ -20,6 +28,7 @@ export default function Button({
     disabled = false,
     customClassName = '',
     onClick,
+    children,
 }: ButtonProps) {
     const getVariantClasses = (variant: ButtonVariant): string => {
         const baseClasses = 'px-4 py-2 rounded-lg font-semibold bg-button hover:bg-button-hover disabled:bg-gray-400 text-button-text cursor-pointer disabled:cursor-not-allowed transition duration-150 ease-in';
@@ -45,7 +54,7 @@ export default function Button({
             onClick={onClick}
             className={finalClassName}
         >
-            {text}
+            {text || children}
         </button>
     );
 }

--- a/src/components/shared/ui/ConfirmDialog.tsx
+++ b/src/components/shared/ui/ConfirmDialog.tsx
@@ -30,7 +30,7 @@ export default function ConfirmDialog({ isOpen, text, onClose, onConfirm, onCall
     };
 
     return (
-        <div className="fixed inset-0 z-50 px-4 sm:px-0 flex items-center justify-center bg-black/30">
+        <div className="dialog-background">
             <div className="bg-white rounded-lg shadow-lg p-4 sm:p-8 sm:w-100 flex flex-col gap-4">
                 <div className='flex justify-between items-center'>
                     <span className="text-lg font-semibold">{text}</span>

--- a/src/components/shared/ui/DateReminder.tsx
+++ b/src/components/shared/ui/DateReminder.tsx
@@ -1,0 +1,14 @@
+import { getTimeRemaining } from '@/components/shared/utils/dateFormats';
+import Image from 'next/image';
+
+/** 모임 마감 알리미 */
+export default function DateReminder({ registrationEnd }: { registrationEnd: string }) {
+    return (
+        <div className="relative px-3 bg-white/80 rounded-full flex items-center text-xs">
+            <div className="absolute top-3 left-3 z-10 bg-main-600 rounded-full px-3 py-1 flex justify-center items-center gap-2">
+                <Image src={"/icons/Alarm.svg"} alt="시간" width={24} height={24} />
+                <span className="font-medium text-white">{getTimeRemaining(registrationEnd)}</span>
+            </div>
+        </div>
+    );
+}

--- a/src/components/shared/ui/Navbar.tsx
+++ b/src/components/shared/ui/Navbar.tsx
@@ -27,7 +27,7 @@ export default function Navbar() {
     return (
         <nav className="sticky z-50 top-0 w-full bg-white border-b-2 border-gray-300 text-xs md:text-base font-bold">
             <div className="max-w-screen-lg mx-auto h-[3.75rem] py-8 px-5 flex justify-between items-center">
-                <section className='flex gap-4 items-center'>
+                <section className='flex gap-2 sm:gap-4 items-center'>
                     <Image
                         src="/images/logo.avif"
                         alt="logo image"

--- a/src/lib/api/apiPaths.ts
+++ b/src/lib/api/apiPaths.ts
@@ -57,5 +57,5 @@ export const INTERNAL_PATHS = {
     cancelGathering: (id: number) => `/api/gatherings/cancel?id=${id}`,
     leaveGathering: (id: number) => `/api/gatherings/leave?id=${id}`,
     FETCH_JOINED_GATHERINGS: `/api/gatherings/joined?&limit=1000`,
-    fetchCreatedGatherings: (userId: number) => `/api/gatherings?createdBy=${userId}&limit=1000`,
+    fetchCreatedGatherings: (userId: number) => `/api/gatherings?createdBy=${userId}&limit=1000&sortBy=registrationEnd`,
 } as const;


### PR DESCRIPTION
## 📌 [refactor] 마이페이지 모바일(sm) 반응형 리팩토링
• 마이페이지의 모든 하위 탭과 다이얼로그의 sm 크기일 때 레이아웃을 적절하게 수정함

## 📌 [refactor] 마이페이지 공통 컴포넌트 분리
• GatheringInformation.tsx
• 참여중인 모임, 나의 리뷰, 내가 만든 모임에서 공통 사용
• 모임 이름, 장소, 참여자 수, 날짜를 렌더링함
• 선택적으로 다른 UI를 자식으로 넘길 수 있음

## 📌 [refactor] 가독성 개선을 위한 섹션 분리
• 나의 리뷰 '작성 가능한 리뷰'의 아이템을 CreatableReview.tsx로 분리
• 나의 리뷰 '작성한 리뷰'의 아이템을 CreatedReview.tsx로 분리

## 📌 [refactor] DateReminder 분리
• 모임 찾기, 모임 상세, 마이페이지의 하위 탭에서 공통으로 사용하는 모임 마감 알리미