### PR TITLE
[fix] 마이페이지 리뷰 관련 버그 해결

### DIFF
--- a/src/components/mypage/CreatableReview.tsx
+++ b/src/components/mypage/CreatableReview.tsx
@@ -1,3 +1,4 @@
+import { useGatheringsStore } from '@/store/gatheringsStore';
 import { Gathering } from '@/types/gatherings';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
@@ -7,6 +8,8 @@ const Button = dynamic(() => import('@/components/shared/ui/Button'), { ssr: fal
 
 /** 나의 리뷰 - 작성 가능한 리뷰 */
 export default function CreatableReview({ gathering, myReviewsTab, userId, onOpenReviewDialog }: { gathering: Gathering, myReviewsTab: number, userId: number, onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void }) {
+    const setCurrentGatheringId = useGatheringsStore(state => state.setCurrentGatheringId);
+
     return (
         <div
             key={gathering.id}
@@ -28,7 +31,10 @@ export default function CreatableReview({ gathering, myReviewsTab, userId, onOpe
                     <Button
                         variant='default'
                         text='리뷰 작성하기'
-                        onClick={() => onOpenReviewDialog({ userId, gatheringId: Number(gathering.id) })}
+                        onClick={() => {
+                            setCurrentGatheringId(Number(gathering.id))
+                            onOpenReviewDialog({ userId, gatheringId: Number(gathering.id) })
+                        }}
                         customClassName='w-28 sm:w-32 text-xs sm:text-base'
                     />
                 )}

--- a/src/components/mypage/CreateReviewDialog.tsx
+++ b/src/components/mypage/CreateReviewDialog.tsx
@@ -85,7 +85,6 @@ export default function CreateReviewDialog({
             onClick={handleSubmit}
             customClassName="w-full"
           />
-
         </div>
       </div>
       <ConfirmDialog
@@ -93,6 +92,7 @@ export default function CreateReviewDialog({
         text={confirmDialog.text}
         onClose={() => setConfirmDialog({ open: false, text: '' })}
         onConfirm={confirmDialog.onConfirm}
+        onCallback={() => onClose()}
       />
     </div>
   );

--- a/src/components/mypage/MyPageUI.tsx
+++ b/src/components/mypage/MyPageUI.tsx
@@ -7,7 +7,7 @@ const ProfileCard = dynamic(() => import('@/components/mypage/ProfileCard'), { s
 const JoinedGatherings = dynamic(() => import('@/components/mypage/JoinedGatherings'), { ssr: false });
 const MyReviews = dynamic(() => import('@/components/mypage/MyReviews'), { ssr: false });
 const CreatedGatherings = dynamic(() => import('@/components/mypage/CreatedGatherings'), { ssr: false });
-const CreateReviewDialog = dynamic(() => import('@/components/mypage/shared/ui/CreateReviewDialog'), { ssr: false });
+const CreateReviewDialog = dynamic(() => import('@/components/mypage/CreateReviewDialog'), { ssr: false });
 
 /** 마이페이지 UI */
 export default function MyPageUI() {

--- a/src/components/shared/ui/Navbar.tsx
+++ b/src/components/shared/ui/Navbar.tsx
@@ -52,13 +52,13 @@ export default function Navbar() {
                     {token && (
                         <DropdownMenu>
                             <DropdownMenuTrigger>
-                                <div className='w-8 h-8 rounded-full border border-gray-300 overflow-hidden'>
+                                <div className='w-8 h-8 rounded-full border border-gray-300 overflow-hidden cursor-pointer'>
                                     <Image
                                         src={userImage && userImage !== 'null' && userImage !== '' ? userImage : '/icons/default_profile_image.svg'}
                                         alt='profile image'
                                         width={1000}
                                         height={1000}
-                                        className='rounded-full cursor-pointer'
+                                        className='size-full rounded-full'
                                     />
                                 </div>
                             </DropdownMenuTrigger>

--- a/src/hooks/api/gatherings/detail/useFetchGatheringDetailReview.ts
+++ b/src/hooks/api/gatherings/detail/useFetchGatheringDetailReview.ts
@@ -33,7 +33,7 @@ export const useFetchGatheringDetailReview = (
 
     const { data, isLoading, isError } = useQuery({
         enabled: !!gatheringId && enabled,
-        queryKey: ['gatheringReviews', gatheringId],
+        queryKey: ["gatheringReviews", gatheringId],
         queryFn: fetchGatheringDetailReviews,
     })
 

--- a/src/hooks/api/mypage/useCreateReview.ts
+++ b/src/hooks/api/mypage/useCreateReview.ts
@@ -5,6 +5,7 @@ import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { GatheringApiParams } from '@/types/gatheringApi';
 import { handleApiError } from '@/lib/api/handleApiResponse';
+import { useGatheringsStore } from '@/store/gatheringsStore';
 
 interface CreateReviewParams {
     gatheringId: number;
@@ -20,6 +21,8 @@ interface CreateReviewParams {
 export const useCreateReview = ({ token, onCallback }: GatheringApiParams) => {
     const queryClient = useQueryClient();
 
+    const currentGatheringId = useGatheringsStore(state => state.currentGatheringId);
+
     const createReview = useMutation({
         mutationFn: async ({ gatheringId, score, comment }: CreateReviewParams) => {
             if (!token) throw new Error('로그인이 필요합니다.');
@@ -28,7 +31,8 @@ export const useCreateReview = ({ token, onCallback }: GatheringApiParams) => {
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["myReviews", token] });
-            queryClient.invalidateQueries({ queryKey: ["gatheringReviews"] });
+            queryClient.invalidateQueries({ queryKey: ["joinedGatherings", token] });
+            queryClient.invalidateQueries({ queryKey: ["gatheringReviews", currentGatheringId] });
             onCallback?.('리뷰가 성공적으로 등록되었습니다');
         },
         onError: (error) => {

--- a/src/store/gatheringsStore.ts
+++ b/src/store/gatheringsStore.ts
@@ -4,18 +4,24 @@ import { Gathering } from '@/types/gatherings';
 /**
  * SSR 모임 목록
  * @type {Gathering[]} gatherings 모임 목록
+ * @type {number | null} currentGatheringId 현재 모임 ID
  * @type {function} setGatherings 모임 목록 설정 함수
+ * @type {function} setCurrentGatheringId 현재 모임 ID 설정 함수
  * @type {function} removeGathering 모임 삭제 함수
  */
 interface GatheringsState {
     gatherings: Gathering[];
+    currentGatheringId: number | null;
     setGatherings: (gatherings: Gathering[]) => void;
+    setCurrentGatheringId: (id: number) => void;
     removeGathering: (id: number) => void;
 }
 
 export const useGatheringsStore = create<GatheringsState>((set) => ({
     gatherings: [],
+    currentGatheringId: null,
     setGatherings: (gatherings) => set({ gatherings }),
+    setCurrentGatheringId: (id: number) => set({ currentGatheringId: id }),
     removeGathering: (id) =>
         set((state) => ({
             gatherings: state.gatherings.filter((g) => g.id !== id),


### PR DESCRIPTION
## 📌 CreateReviewDialog useCreateReview 이후 바로 안 닫힘
• onCallback={() => onClose()} 추가

## 📌 리뷰 작성후 '나의 리뷰' - '작성한 리뷰'에 바로 반영되지 않음
• queryClient.invalidateQueries({ queryKey: ["joinedGatherings", token] }) 추가

## 📌 리뷰 작성후 모임 상세 페이지에 바로 반영되지 않음
• queryClient.invalidateQueries({ queryKey: ["gatheringReviews", currentGatheringId] }) 추가
• useGatheringStore(zustand)에 currentGatheringId와 setCurrentGatheringId 추가
• 작성 가능한 리뷰 컴포넌트에서 '리뷰 작성하기' 버튼을 누르면 해당 모임의 ID가 전역 상태에 동기화
• useCreateReview에서 해당 ID를 참조하여 invalidQueries로 캐시 트리거