### PR TITLE
[refactor] 중간발표 피드백 적용

### DIFF
--- a/src/app/api/gatherings/cancel/route.ts
+++ b/src/app/api/gatherings/cancel/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { AxiosError } from 'axios';
 import { externalClient } from '@/lib/api/clientFetchers';
+import { handleApiError } from '@/lib/api/handleApiError';
 
 /**
  * 모임 취소
@@ -22,7 +22,6 @@ export async function PUT(request: NextRequest) {
         const response = await externalClient.put(EXTERNAL_PATHS.cancelGathering(id), {}, { headers: { 'Authorization': token } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
-        const err = error as AxiosError;
-        return new NextResponse(JSON.stringify({ error: err?.response?.data }), { status: 500 });
+        return handleApiError(error);
     }
 }

--- a/src/app/api/gatherings/join/route.ts
+++ b/src/app/api/gatherings/join/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { AxiosError } from 'axios';
 import { externalClient } from '@/lib/api/clientFetchers';
+import { handleApiError } from '@/lib/api/handleApiError';
 
 /**
  * 모임 참여 
@@ -22,7 +22,6 @@ export async function POST(request: NextRequest) {
         const response = await externalClient.post(EXTERNAL_PATHS.joinGathering(id), {}, { headers: { 'Authorization': token } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
-        const err = error as AxiosError;
-        return new NextResponse(JSON.stringify({ error: err?.response?.data }), { status: 500 });
+        return handleApiError(error);
     }
 }

--- a/src/app/api/gatherings/joined/route.ts
+++ b/src/app/api/gatherings/joined/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { AxiosError } from 'axios';
 import { externalClient } from '@/lib/api/clientFetchers';
+import { handleApiError } from '@/lib/api/handleApiError';
 
 /**
  * 모임 참여 확인
@@ -20,7 +20,6 @@ export async function GET(request: NextRequest) {
 
         return NextResponse.json(response.data);
     } catch (error) {
-        const err = error as AxiosError;
-        return new NextResponse(JSON.stringify({ error: err?.response?.data }), { status: 500 });
+        return handleApiError(error);
     }
 }

--- a/src/app/api/gatherings/leave/route.ts
+++ b/src/app/api/gatherings/leave/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { AxiosError } from 'axios';
+import { handleApiError } from '@/lib/api/handleApiError';
 import { externalClient } from '@/lib/api/clientFetchers';
 
 /**
@@ -22,7 +22,6 @@ export async function DELETE(request: NextRequest) {
         const response = await externalClient.delete(EXTERNAL_PATHS.leaveGathering(id), { headers: { 'Authorization': token } });
         return new NextResponse(JSON.stringify(response.data), { status: 200 });
     } catch (error) {
-        const err = error as AxiosError;
-        return new NextResponse(JSON.stringify({ error: err?.response?.data }), { status: 500 });
+        return handleApiError(error);
     }
 }

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
-import axios, { AxiosError } from 'axios';
+import { handleApiError } from '@/lib/api/handleApiError';
 import { externalClient } from '@/lib/api/clientFetchers';
 
 /**
@@ -24,8 +24,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(response.data);
   } catch (error) {
-    const err = error as AxiosError;
-    return new NextResponse(JSON.stringify({ error: err?.response?.data }), { status: 500 });
+    return handleApiError(error);
   }
 }
 
@@ -47,15 +46,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(response.data);
   } catch (error) {
-    console.error('리뷰 생성 중 오류:', error);
-
-    if (axios.isAxiosError(error) && error.response) {
-      return NextResponse.json(error.response.data, { status: error.response.status });
-    }
-
-    return NextResponse.json(
-      { code: 'SERVER_ERROR', message: '리뷰 생성에 실패했습니다.' },
-      { status: 500 }
-    );
+    return handleApiError(error);
   }
 }

--- a/src/components/gatherings/detail/Footer.tsx
+++ b/src/components/gatherings/detail/Footer.tsx
@@ -19,7 +19,7 @@ interface FooterProps {
 }
 
 /** 모임 상세 페이지 Footer */
-export default function Footer({ userId, detail, isParticipated, leaveGathering, joinGathering, token, setDialogOpen, handleCopyUrl, id, setSignInDialogOpen }: FooterProps) {
+export default function Footer({ userId, token, id, detail, isParticipated, leaveGathering, joinGathering, setDialogOpen, handleCopyUrl, setSignInDialogOpen }: FooterProps) {
     return (
         <footer className='sticky bottom-0 w-full h-16 border-t border-gray-300 bg-white' >
             <div className='max-w-screen-lg h-full mx-auto px-4 md:px-20 flex justify-between items-center'>

--- a/src/components/gatherings/detail/GatheringDetailUI.tsx
+++ b/src/components/gatherings/detail/GatheringDetailUI.tsx
@@ -33,7 +33,7 @@ const LIMIT = 4;
 
 /** 모임 상세 페이지 UI */
 export default function GatheringsDetailUI({ id, detailReviews }: { id: string, detailReviews: Reviews }) {
-    const { token, userId, signInDialogOpen, setSignInDialogOpen } = useContext(AuthContext);
+    const { token, userId, signInDialogOpen, setSignInDialogOpen, signOut } = useContext(AuthContext);
 
     const [page, setPage] = useState(detailReviews?.currentPage ?? 1);
     const [reviews, setReviews] = useState<ReviewItem[]>(detailReviews.data);
@@ -44,7 +44,7 @@ export default function GatheringsDetailUI({ id, detailReviews }: { id: string, 
     const offset = (page - 1) * LIMIT;
 
     const { detail, participants, isLoading: detailLoading } = useFetchGatheringDetail(Number(id));
-    const { data: isParticipated, } = useCheckJoined(Number(id), token);
+    const { data: isParticipated, errorMessage } = useCheckJoined(Number(id), token);
     const { data: nextPageData, isLoading: reviewsLoading } = useFetchGatheringDetailReview(
         Number(id),
         LIMIT,
@@ -66,20 +66,26 @@ export default function GatheringsDetailUI({ id, detailReviews }: { id: string, 
     });
 
     useEffect(() => {
-        if (page === 1) {
-            setReviews(detailReviews.data);
-        } else if (nextPageData) {
-            setReviews(nextPageData.data);
-        }
+        if (page === 1) setReviews(detailReviews.data);
+        else if (nextPageData) setReviews(nextPageData.data);
     }, [page, nextPageData, detailReviews.data]);
+
+    useEffect(() => {
+        if (errorMessage) {
+            if (errorMessage === '로그인이 만료되었습니다') {
+                openConfirmDialog(setDialog, errorMessage, () => {
+                    signOut()
+                    router.push('/signin')
+                });
+            }
+        }
+    }, [router, errorMessage, setSignInDialogOpen, signOut]);
 
     const queryClient = useQueryClient();
 
     const handleDeleteConfirm = () => {
         cancelGathering(Number(id));
-
         queryClient.invalidateQueries({ queryKey: ['gatherings'] });
-
         setDialog((prev) => ({ ...prev, isOpen: false }));
     };
 

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -2,9 +2,9 @@
 
 import { useFetchJoinedGatherings } from '@/hooks/api/mypage/useFetchJoinedGatherings';
 import { useLeaveGathering } from '@/hooks/api/gatherings/detail/useLeaveGathering';
-import { useContext, useState } from 'react';
+import { useContext, useState, useEffect } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
-import { getTimeRemaining } from '@/components/shared/utils/dateFormats';
+import { getTimeRemaining, toKoreanTime } from '@/components/shared/utils/dateFormats';
 import { CheckCircle } from "lucide-react"
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
@@ -24,12 +24,12 @@ interface JoinedGatheringsProps {
 
 /** 마이페이지 '참여중인 모임' */
 export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOpenReviewDialog }: JoinedGatheringsProps) {
-  const { token, userId } = useContext(AuthContext);
+  const { token, userId, signOut } = useContext(AuthContext);
 
   const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
-  const { data: gatherings = [], isLoading, error } = useFetchJoinedGatherings(token!);
+  const { data: gatherings = [], isLoading, error, errorMessage: fetchErrorMessage } = useFetchJoinedGatherings(token!);
 
   const { leaveGathering } = useLeaveGathering({
     token,
@@ -39,18 +39,33 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
     },
   });
 
-  const sortedGatherings = [...gatherings].sort((a, b) => {
-    if (a.isCompleted === b.isCompleted) {
-      const A_REGISTRATION_END = new Date(a.registrationEnd || '').getTime();
-      const B_REGISTRATION_END = new Date(b.registrationEnd || '').getTime();
-      return B_REGISTRATION_END - A_REGISTRATION_END;
+  // 참여 모임 데이터 페칭 에러 발생 시, 에러 메시지 팝업 (토큰 만료)
+  useEffect(() => {
+    if (fetchErrorMessage) {
+      setErrorMessage(fetchErrorMessage);
+      setIsErrorDialogOpen(true);
     }
+  }, [fetchErrorMessage]);
+
+  const handleErrorDialogClose = () => {
+    setIsErrorDialogOpen(false);
+    if (errorMessage === '로그인이 만료되었습니다') signOut();
+  };
+
+  const sortedGatherings = [...gatherings].sort((a, b) => {
+    // 완료 상태가 같은 경우, 마감일 기준으로 정렬 (최신 마감일 우선)
+    if (a.isCompleted === b.isCompleted) {
+      const aRegistrationEnd = a.registrationEnd ? toKoreanTime(a.registrationEnd).getTime() : 0;
+      const bRegistrationEnd = b.registrationEnd ? toKoreanTime(b.registrationEnd).getTime() : 0;
+      return bRegistrationEnd - aRegistrationEnd;
+    }
+    // 완료되지 않은 모임을 먼저 표시
     return a.isCompleted ? 1 : -1;
   });
 
   if (isLoading) return <LoadingUI />;
-  if (error) return <div className="text-red-500">에러: {error.message}</div>;
-  if (gatherings.length === 0) return <div className="text-gray-500 text-center">참여한 모임이 없습니다</div>;
+  if (error && !fetchErrorMessage) return <div className="text-red-500">에러: {error.message}</div>;
+  if (gatherings.length === 0 && !error) return <div className="text-gray-500 text-center">참여한 모임이 없습니다</div>;
 
   return (
     <section className='px-4 flex flex-col gap-2'>
@@ -146,7 +161,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
       <ConfirmDialog
         isOpen={isErrorDialogOpen}
         text={errorMessage}
-        onClose={() => setIsErrorDialogOpen(false)}
+        onClose={handleErrorDialogClose}
       />
     </section>
   );

--- a/src/components/mypage/MyReviews.tsx
+++ b/src/components/mypage/MyReviews.tsx
@@ -74,7 +74,7 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
             <span className="text-gray-500 text-center">아직 작성한 리뷰가 없어요</span>
             :
             <div
-              className="relative min-h-[100px] w-full p-4 rounded-xl flex gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
+              className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item"
             >
               {createdReviews?.map((review: ReviewItem) => (
                 <div key={`${review?.Gathering?.id}-${review?.id}`}><CreatedReview review={review} /></div>

--- a/src/hooks/api/gatherings/detail/useCancelGathering.ts
+++ b/src/hooks/api/gatherings/detail/useCancelGathering.ts
@@ -6,7 +6,8 @@ import { GatheringApiParams } from '@/types/gatheringApi';
 import { useRouter } from 'next/navigation';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { handleApiError } from '@/lib/api/handleApiResponse';
+import { AxiosError } from 'axios';
+import { isErrorResponse } from '@/lib/api/handleApiError';
 
 /** 모임 삭제 훅
 * @param token 토큰
@@ -33,16 +34,9 @@ export const useCancelGathering = ({ token, onCallback }: GatheringApiParams) =>
             onCallback?.('모임을 삭제했습니다', () => router.replace('/gatherings'));
         },
         onError: (error) => {
-            const response = handleApiError(error);
-            response.text().then(text => {
-                try {
-                    const json = JSON.parse(text);
-                    const message = json?.error?.message || json?.message || text;
-                    onCallback?.(message);
-                } catch {
-                    onCallback?.(text);
-                }
-            });
+            const err = error as AxiosError;
+            const message = (isErrorResponse(err?.response?.data) && err?.response?.data.message) || '모임 취소에 실패했습니다';
+            onCallback?.(message);
         }
     });
 

--- a/src/hooks/api/gatherings/detail/useCheckJoined.ts
+++ b/src/hooks/api/gatherings/detail/useCheckJoined.ts
@@ -4,7 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { JoinedGathering } from '@/types/gatherings';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
-import axios from 'axios';
+import { isErrorResponse } from '@/lib/api/handleApiError';
+import { AxiosError } from 'axios';
 
 /** 
  * 모임 참여 확인 훅
@@ -15,26 +16,22 @@ export const useCheckJoined = (
     id: number,
     token: string | null
 ) => {
-
     const checkJoined = async () => {
-        try {
-            const response = await internalClient.get(INTERNAL_PATHS.CHECK_JOINED, { headers: { Authorization: `Bearer ${token}` } },);
-            return response.data.some((gathering: JoinedGathering) => gathering.id === Number(id))
-        } catch (error) {
-            if (axios.isAxiosError(error)) {
-                const serverError = error?.response?.data?.error;
-                console.error(serverError?.message);
-            }
-            return false;
-        }
+        const response = await internalClient.get(INTERNAL_PATHS.CHECK_JOINED, { headers: { Authorization: `Bearer ${token}` } },);
+        return response.data.some((gathering: JoinedGathering) => gathering.id === Number(id))
     }
 
-    const { data, isLoading, isError } = useQuery({
+    const { data, isLoading, isError, error } = useQuery({
         enabled: !!id && !!token,
         queryKey: ['checkGatheringJoined', id],
         queryFn: () => checkJoined(),
     })
 
-    return { data, isLoading, isError }
+    const errorMessage = error ? (() => {
+        const err = error as AxiosError;
+        return (isErrorResponse(err?.response?.data) && err?.response?.data.message) || '참여 확인에 실패했습니다';
+    })() : null;
+
+    return { data, isLoading, isError, errorMessage }
 }
 

--- a/src/hooks/api/gatherings/detail/useJoinGathering.ts
+++ b/src/hooks/api/gatherings/detail/useJoinGathering.ts
@@ -4,7 +4,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
 import { GatheringApiParams } from '@/types/gatheringApi';
 import { internalClient } from '@/lib/api/clientFetchers';
-import { handleApiError } from '@/lib/api/handleApiResponse';
+import { AxiosError } from 'axios';
+import { isErrorResponse } from '@/lib/api/handleApiError';
 
 /** 모임 참여 훅
 * @param token 토큰
@@ -28,16 +29,9 @@ export const useJoinGathering = ({ token, onCallback }: GatheringApiParams) => {
             onCallback?.('참여 완료했습니다');
         },
         onError: (error) => {
-            const response = handleApiError(error);
-            response.text().then(text => {
-                try {
-                    const json = JSON.parse(text);
-                    const message = json?.error?.message || json?.message || text;
-                    onCallback?.(message);
-                } catch {
-                    onCallback?.(text);
-                }
-            });
+            const err = error as AxiosError;
+            const message = (isErrorResponse(err?.response?.data) && err?.response?.data.message) || '참여에 실패했습니다';
+            onCallback?.(message);
         }
     });
 

--- a/src/hooks/api/gatherings/detail/useLeaveGathering.ts
+++ b/src/hooks/api/gatherings/detail/useLeaveGathering.ts
@@ -4,7 +4,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { GatheringApiParams } from '@/types/gatheringApi';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { handleApiError } from '@/lib/api/handleApiResponse';
+import { AxiosError } from 'axios';
+import { isErrorResponse } from '@/lib/api/handleApiError';
 
 /** 모임 참여 취소 훅
 * @param token 토큰
@@ -28,16 +29,9 @@ export const useLeaveGathering = ({ token, onCallback }: GatheringApiParams) => 
             onCallback?.('참여 취소했습니다');
         },
         onError: (error) => {
-            const response = handleApiError(error);
-            response.text().then(text => {
-                try {
-                    const json = JSON.parse(text);
-                    const message = json?.error?.message || json?.message || text;
-                    onCallback?.(message);
-                } catch {
-                    onCallback?.(text);
-                }
-            });
+            const err = error as AxiosError;
+            const message = (isErrorResponse(err?.response?.data) && err?.response?.data.message) || '참여 취소에 실패했습니다';
+            onCallback?.(message);
         }
     });
 

--- a/src/hooks/api/gatherings/useCreateGathering.ts
+++ b/src/hooks/api/gatherings/useCreateGathering.ts
@@ -4,7 +4,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { GatheringApiParams } from '@/types/gatheringApi';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { handleApiError } from '@/lib/api/handleApiResponse';
+import { AxiosError } from 'axios';
+import { isErrorResponse } from '@/lib/api/handleApiError';
 
 /**
  * 모임 생성 훅
@@ -27,16 +28,9 @@ export const useCreateGathering = ({ token, onCallback }: GatheringApiParams) =>
             onCallback?.('모임을 생성했습니다');
         },
         onError: (error) => {
-            const response = handleApiError(error);
-            response.text().then(text => {
-                try {
-                    const json = JSON.parse(text);
-                    const message = json?.error?.message || json?.message || text;
-                    onCallback?.(message);
-                } catch {
-                    onCallback?.(text);
-                }
-            });
+            const err = error as AxiosError;
+            const message = (isErrorResponse(err?.response?.data) && err?.response?.data.message) || '모임 생성에 실패했습니다';
+            onCallback?.(message);
         }
     });
 

--- a/src/hooks/api/mypage/useCreateReview.ts
+++ b/src/hooks/api/mypage/useCreateReview.ts
@@ -4,8 +4,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { GatheringApiParams } from '@/types/gatheringApi';
-import { handleApiError } from '@/lib/api/handleApiResponse';
 import { useGatheringsStore } from '@/store/gatheringsStore';
+import { AxiosError } from 'axios';
+import { isErrorResponse } from '@/lib/api/handleApiError';
 
 interface CreateReviewParams {
     gatheringId: number;
@@ -36,16 +37,9 @@ export const useCreateReview = ({ token, onCallback }: GatheringApiParams) => {
             onCallback?.('리뷰가 성공적으로 등록되었습니다');
         },
         onError: (error) => {
-            const response = handleApiError(error);
-            response.text().then(text => {
-                try {
-                    const json = JSON.parse(text);
-                    const message = json?.error?.message || json?.message || text;
-                    onCallback?.(message);
-                } catch {
-                    onCallback?.(text);
-                }
-            });
+            const err = error as AxiosError;
+            const message = (isErrorResponse(err?.response?.data) && err?.response?.data.message) || '리뷰 작성에 실패했습니다';
+            onCallback?.(message);
         }
     });
 

--- a/src/hooks/api/mypage/useFetchJoinedGatherings.ts
+++ b/src/hooks/api/mypage/useFetchJoinedGatherings.ts
@@ -4,15 +4,15 @@ import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { JoinedGathering } from '@/types/gatherings';
 import { useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { isErrorResponse } from '@/lib/api/handleApiError';
 
 /** 
  * 참여한 모임 목록 조회 훅
  * @param token
- * @returns {data, isLoading, isError}
+ * @returns {data, isLoading, error, errorMessage}
  */
-export const useFetchJoinedGatherings = (
-    token: string
-) => {
+export const useFetchJoinedGatherings = (token: string) => {
     const fetchJoinedGatherings = async (): Promise<JoinedGathering[]> => {
         const { data } = await internalClient.get(INTERNAL_PATHS.FETCH_JOINED_GATHERINGS);
         return data;
@@ -24,8 +24,13 @@ export const useFetchJoinedGatherings = (
         queryFn: async () => {
             const response = await fetchJoinedGatherings()
             return response
-        },
-    })
+        }
+    });
 
-    return { data, isLoading, error }
+    const errorMessage = error ? (() => {
+        const err = error as AxiosError;
+        return (isErrorResponse(err?.response?.data) && err?.response?.data.message) || '데이터를 불러오는데 실패했습니다';
+    })() : null;
+
+    return { data, isLoading, error, errorMessage }
 }

--- a/src/lib/api/apiPaths.ts
+++ b/src/lib/api/apiPaths.ts
@@ -56,6 +56,6 @@ export const INTERNAL_PATHS = {
     joinGathering: (id: number) => `/api/gatherings/join?id=${id}`,
     cancelGathering: (id: number) => `/api/gatherings/cancel?id=${id}`,
     leaveGathering: (id: number) => `/api/gatherings/leave?id=${id}`,
-    FETCH_JOINED_GATHERINGS: `/api/gatherings/joined?&limit=1000`,
-    fetchCreatedGatherings: (userId: number) => `/api/gatherings?createdBy=${userId}&limit=1000&sortBy=registrationEnd`,
+    FETCH_JOINED_GATHERINGS: `/api/gatherings/joined?&limit=100`,
+    fetchCreatedGatherings: (userId: number) => `/api/gatherings?createdBy=${userId}&limit=100&sortBy=registrationEnd`,
 } as const;

--- a/src/lib/api/handleApiError.ts
+++ b/src/lib/api/handleApiError.ts
@@ -1,14 +1,20 @@
 import { NextResponse } from 'next/server';
 import { AxiosError } from 'axios';
 
-/**
- * 성공 응답 처리
- * @param data - 응답 데이터
- * @param status - 응답 상태 코드
- * @returns {NextResponse} 응답 객체
+export interface ErrorResponse {
+    code?: string;
+    message?: string;
+    [key: string]: unknown;
+}
+
+/** 
+ * 에러 응답 타입 가드 함수
+ * @description 에러 응답 데이터가 ErrorResponse 타입인지 확인
+ * @param data - 에러 응답 데이터
+ * @returns {boolean}
  */
-export function handleApiSuccess(data: unknown, status: number = 200) {
-    return new NextResponse(JSON.stringify(data), { status });
+export function isErrorResponse(data: unknown): data is ErrorResponse {
+    return typeof data === 'object' && data !== null;
 }
 
 /**
@@ -21,13 +27,22 @@ export function handleApiSuccess(data: unknown, status: number = 200) {
 export function handleApiError(error: unknown, fallbackMessage = '서버 에러 확인이 필요합니다', fallbackStatus = 500) {
     if (error && typeof error === 'object' && 'isAxiosError' in error && (error as AxiosError).isAxiosError) {
         const err = error as AxiosError;
-        // 서버에서 응답이 온 경우
-        if (err.response) return new NextResponse(JSON.stringify(err.response.data), { status: err.response.status || fallbackStatus });
-        // 요청은 갔으나 응답이 없는 경우
+
+        if (err.response) {
+            if (err.response.status === 401 &&
+                isErrorResponse(err.response.data) &&
+                err.response.data.message === '유효하지 않은 토큰입니다') {
+                return new NextResponse(JSON.stringify({
+                    ...err.response.data,
+                    message: '로그인이 만료되었습니다'
+                }), { status: err.response.status });
+            }
+
+            return new NextResponse(JSON.stringify(err.response.data), { status: err.response.status || fallbackStatus });
+        }
         else if (err.request) return new NextResponse(JSON.stringify({ code: 'SERVER_ERROR', message: '서버에서 응답이 없습니다.' }), { status: 500 });
-        // 요청 자체가 잘못된 경우
         else return new NextResponse(JSON.stringify({ code: 'REQUEST_ERROR', message: err.message || fallbackMessage }), { status: 500 });
     }
-    // AxiosError가 아닌 경우
+
     return new NextResponse(JSON.stringify({ code: 'SERVER_ERROR', message: fallbackMessage }), { status: fallbackStatus });
 }

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -42,7 +42,6 @@ export const AuthContext = createContext<AuthContextType>({
     userImage: '',
 });
 
-
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
     const [token, setToken] = useState<string | null>(null);
     const [userName, setUserName] = useState('이름');
@@ -133,8 +132,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         setUserImage(data.image);
     };
 
-
-    // 페이지 이동 시 토큰, 유저명, 유저 아이디 감지 (처음 한 번)
+    /** 페이지 이동 시 유저 정보 감지 */
     useEffect(() => {
         const checkAuth = () => {
             const storedToken = localStorage.getItem('token');
@@ -157,11 +155,14 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         checkAuth();
     }, []);
 
+    /** Protect Routes */
     useEffect(() => {
         if (isLoading) return; // 로딩 중이면 아무것도 하지 않음
-        if (!token && pathname.startsWith('/mypage')) setSignInDialogOpen(true); // 마이페이지 접근 시 로그인 확인
-        if (pathname !== '/signin' && !pathname.includes('/auth/')) setPreviousPath(pathname); // 로그인 후 이전 경로 저장
-        if (token && pathname === '/signin') router.replace(previousPath); // 로그인 후 로그인 페이지 접근 시 이전 경로로 이동
+        if (!token && pathname === '/mypage') setSignInDialogOpen(true); // 마이페이지: 로그인 필요
+        if (!token && pathname === '/saved') setSignInDialogOpen(true); // 찜한 모임: 로그인 필요
+        if (pathname !== '/signin' && !pathname.includes('/auth')) setPreviousPath(pathname); // 로그인 후 이전 경로 저장
+        if (token && pathname === '/signin') router.replace(previousPath); // 로그인: 로그인 되어있는 경우, 이전 경로로 이동
+        if (token && pathname === '/signup') router.replace('/'); // 회원가입: 로그인 되어있는 경우, 메인페이지로 이동(이건 직접 주소 입력으로 뚫고 들어오는 경우 때문에 추가)
     }, [isLoading, token, pathname, router, previousPath]);
 
     const handleSignInModalConfirm = () => {


### PR DESCRIPTION
## 📌 handleApiError를 API 라우트 에러 핸들링으로 이동
• 기존에는 각 useMutation 로직을 담고 있는 커스텀 훅의 onError에서 사용중이었음
• 커스텀 훅이 요청하는 API 라우트의 catch문에서 사용하는 것으로 변경
• 커스텀 훅은 API 라우트가 handleApiError로 반환한 에러의 메세지를 onCallback(ConfirmDialog를 위해 넘겨받은 콜백 props)에 전달만 함

## 📌 로그인 상태에서 회원가입 페이지 접근 방지
• 회원가입 -> 로그인 -> previousPath 이동 때문에 로그인 하고 나서 회원가입으로 이동하는 상황 존재
• 로그인 상태에서 회원가입 페이지로 이동하려하면 메인 페이지로 보내버리는 걸로 처리함

## 📌 찜한 모임 페이지 비로그인 유저 접근 방지

## 📌 '유효하지 않은 토큰입니다'가 바로 팝업에 표시되지 않게 UI 처리
• 액세스 토큰 만료(로그인 후 1시간 초과)시, token이 헤더에 필요한 API 요청시 401 에러 발생
• 이때 handleApiError가 API 라우트마다 에러핸들링을 맡고 있으니, 클라이언트로 주는 에러 객체에는 '로그인이 만료되었습니다'라는 메세지로 바꿔서 반환
• 마이페이지 '참여중인 모임'에서는 useFetchJoinedGatherings의 fetchErrorMessage가 응답 오면 팝업으로 메세지를 나타내고 확인을 누르면 로그아웃 & 로그인 이동
• 모임 상세 페이지에서 useCheckJoined의 errorMessage가 응답 오면 팝업으로 메세지를 나타내고 확인을 누르면 로그아웃 & 로그인 이동