### PR TITLE
3commits: 마감 처리 변경, 찜페이지 로직 개선, 마감 정렬 함수 정리

### DIFF
--- a/src/components/gatherings/GatheringsList.tsx
+++ b/src/components/gatherings/GatheringsList.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useFetchInfiniteGatherings } from "@/hooks/api/gatherings/useFetchInfiniteGatherings";
 import { useMemo } from 'react';
-import { formatDate, formatTime, isGatheringExpired } from '@/components/shared/utils/dateFormats';
+import { formatDate, formatTime, getTimeRemaining } from '@/components/shared/utils/dateFormats';
 import { Gathering } from "@/types/gatherings";
 import { UserRoundCheck } from "lucide-react";
 import Image from "next/image";
@@ -12,7 +12,18 @@ import dynamic from 'next/dynamic';
 const JoinedCountsProgressBar = dynamic(() => import('@/components/gatherings/shared/ui/JoinedCountsProgressBar'), { ssr: false });
 const SaveToggleButton = dynamic(() => import('@/components/gatherings/shared/ui/SaveToggleButton'), { ssr: false });
 const DateReminder = dynamic(() => import('@/components/shared/ui/DateReminder'), { ssr: false });
+const OverlayForDisabled = dynamic(() => import('@/components/shared/ui/OverlayForDisabled'), { ssr: false });
 
+/**
+ * 모임 목록 컴포넌트 props
+ * @param ssrGatherings 서버 렌더링 모임 목록
+ * @param selectedMainType 선택된 모임 주제
+ * @param selectedSubType 선택된 모임 서브타입
+ * @param filters 필터 조건
+ * @param sort 정렬 조건
+ * @param enableInfiniteScroll 무한 스크롤 활성화 여부
+ * @param savedGatheringIds 찜한 모임 ID 목록
+ */
 interface GatheringsListProps {
     ssrGatherings: Gathering[];
     selectedMainType: string;
@@ -27,7 +38,6 @@ interface GatheringsListProps {
     };
     enableInfiniteScroll?: boolean;
     savedGatheringIds?: string[];
-    excludeExpired?: boolean;
 }
 
 /**
@@ -81,6 +91,18 @@ const removeDuplicateGatherings = (gatherings: Gathering[]): Gathering[] => {
     return result;
 };
 
+/**
+ * 모임이 마감되었는지 확인하는 함수
+ * @param gathering 모임 정보
+ * @returns 마감 여부
+ */
+const isGatheringClosed = (gathering: Gathering): boolean => {
+    if (!gathering.registrationEnd) return false;
+    
+    const timeRemaining = getTimeRemaining(gathering.registrationEnd);
+    return timeRemaining === '마감됨';
+};
+
 export default function GatheringsList({
     ssrGatherings,
     selectedMainType,
@@ -89,7 +111,6 @@ export default function GatheringsList({
     sort,
     enableInfiniteScroll = true,
     savedGatheringIds = [],
-    excludeExpired = true
 }: GatheringsListProps) {
     const router = useRouter();
     const isSavedPage = savedGatheringIds.length > 0;
@@ -107,21 +128,14 @@ export default function GatheringsList({
         sortBy: sort.sortBy,
         sortOrder: sort.sortOrder,
         startPage: 1,
-        excludeExpired
     });
 
-    // SSR 데이터 타입 필터링 및 마감된 모임 필터링
+    // SSR 데이터 타입
     const filteredSSRGatherings = useMemo(() => {
         const result = filterGatheringsByType(ssrGatherings, selectedMainType, selectedSubType);
         
-        // 마감된 모임 제외
-        if (excludeExpired) {
-            const filteredResult = result.filter(gathering => !isGatheringExpired(gathering.registrationEnd));
-            return filteredResult;
-        }
-
         return result;
-    }, [ssrGatherings, selectedMainType, selectedSubType, excludeExpired]);
+    }, [ssrGatherings, selectedMainType, selectedSubType]);
 
     // CSR 데이터 타입 필터링
     const filteredCSRGatherings = useMemo(() => {
@@ -148,20 +162,24 @@ export default function GatheringsList({
         return title.length > maxLength ? title.slice(0, maxLength) + '...' : title;
     };
 
-
     return (
         <div className="w-full flex flex-col justify-start gap-5">
             {allGatherings.map((gathering: Gathering, index: number) => {
                 const isLastItem = index === allGatherings.length - 1;
+                const isClosed = isGatheringClosed(gathering);
 
                 return (
                     <section
                         role="button"
                         tabIndex={0}
                         key={`${gathering.teamId || 'unknown'}-${gathering.id}-${index}`}
-                        onClick={() => router.push(`/gatherings/detail/${gathering.id}`)}
+                        onClick={() => !isClosed && router.push(`/gatherings/detail/${gathering.id}`)}
                         ref={isLastItem && !isFetchingNextPage && enableInfiniteScroll && !isSavedPage ? lastItemRef : undefined}
-                        className="w-full flex flex-col md:flex-row justify-start border border-gray-200 rounded-2xl bg-white hover:border-main-300 hover:shadow-lg transition-all duration-300 overflow-hidden relative"
+                        className={`w-full flex flex-col md:flex-row justify-start border border-gray-200 rounded-2xl bg-white transition-all duration-300 overflow-hidden relative ${
+                            isClosed 
+                                ? 'cursor-not-allowed opacity-75' 
+                                : 'hover:border-main-300 hover:shadow-lg cursor-pointer'
+                        }`}
                     >
                         {/* 이미지 영역 */}
                         <div className="w-full md:w-80 h-48 md:h-40 relative flex-shrink-0">
@@ -225,12 +243,20 @@ export default function GatheringsList({
                                 </div>
                             </div>
                         </div>
+
+                        {/* 마감된 모임에 오버레이 적용 */}
+                        <OverlayForDisabled
+                            emoji=''
+                            filterings={isClosed}
+                            notice="모집 마감"
+                            reason="등록 기간이 종료되었습니다"
+                        />
                     </section>
                 );
             })}
 
             {/* 무한스크롤 로딩 */}
-            {enableInfiniteScroll && !isSavedPage && isFetchingNextPage && (
+            {enableInfiniteScroll && isFetchingNextPage && (
                 <div className="w-full h-[80px] flex justify-center items-center">
                     <div className="flex items-center gap-3">
                         <div className="w-6 h-6 border-3 border-main-500 border-t-transparent rounded-full animate-spin"></div>
@@ -242,17 +268,8 @@ export default function GatheringsList({
             {/* 빈 목록 메시지 */}
             {!isLoading && allGatherings.length === 0 && (
                 <div className="w-full h-[300px] flex flex-col justify-center items-center text-gray-500 font-medium text-sm">
-                    {isSavedPage ? (
-                        <>
-                            <p className="text-lg font-semibold mb-2">선택한 카테고리에 찜한 모임이 없어요</p>
-                            <p>다른 카테고리를 확인해보세요</p>
-                        </>
-                    ) : (
-                        <>
-                            <p>선택한 조건에 맞는 모임이 없어요,</p>
-                            <p>다른 조건으로 검색해보세요</p>
-                        </>
-                    )}
+                    <p className="text-lg font-semibold mb-2">아직 모임이 없어요</p>
+                    <p>곧 새로운 모임이 열릴 예정이에요</p>
                 </div>
             )}
         </div>

--- a/src/components/gatherings/GatheringsUI.tsx
+++ b/src/components/gatherings/GatheringsUI.tsx
@@ -157,7 +157,6 @@ export default function Gatherings({ ssrGatherings, initialFilters }: Gatherings
                     sort={currentSort}
                     enableInfiniteScroll={true}
                     savedGatheringIds={[]}
-                    excludeExpired={true}
                 />
             </div>
 

--- a/src/components/gatherings/shared/ui/SaveToggleButton.tsx
+++ b/src/components/gatherings/shared/ui/SaveToggleButton.tsx
@@ -1,51 +1,60 @@
-"use client"
+'use client';
 
-import React from 'react';
-import { useToggleSavedGatherings } from "@/hooks/api/saved/useToggleSavedGatherings";
+import { useContext } from 'react';
+import { Heart } from 'lucide-react';
+import { useToggleSavedGatherings } from '@/hooks/api/saved/useToggleSavedGatherings';
+import { AuthContext } from '@/providers/AuthProvider';
 
 interface SaveToggleButtonProps {
     gatheringId: string;
-    className?: string;
 }
 
 /**
- * 모임 찜하기/찜 해제 토글 버튼 컴포넌트
- * @param {SaveToggleButtonProps} props - 컴포넌트 props
- * @param {string} props.gatheringId - 찜할 모임의 ID
- * @param {string} [props.className] - 추가 CSS 클래스명
- * @returns {JSX.Element} 찜하기 토글 버튼
+ * 찜하기/찜 해제 토글 버튼
+ * @param gatheringId 모임 ID
  */
-export default function SaveToggleButton({
-    gatheringId,
-    className = ''
-}: SaveToggleButtonProps) {
+export default function SaveToggleButton({ gatheringId }: SaveToggleButtonProps) {
+    const { token, setSignInDialogOpen } = useContext(AuthContext);
+    const isAuthenticated = !!token;
+    
     const { savedIds, toggleSaved, isToggling } = useToggleSavedGatherings();
     const isSaved = savedIds.includes(gatheringId);
 
+    const handleToggleClick = (e: React.MouseEvent) => {
+        e.stopPropagation(); // 부모 요소 클릭 이벤트 방지
+
+        // 로그인 상태 확인
+        if (!isAuthenticated) {
+            setSignInDialogOpen(true);
+            return;
+        }
+
+        // 로그인된 경우 찜하기 토글 실행
+        toggleSaved(gatheringId);
+    };
+
     return (
         <button
-            onClick={() => toggleSaved(gatheringId)}
+            onClick={handleToggleClick}
             disabled={isToggling}
             className={`
-                flex-shrink-0 w-12 h-12 rounded-full border-2 transition-all duration-200
-                ${isSaved
-                    ? 'bg-main-50 border-main-300 text-main-600 hover:bg-main-100 hover:text-main-600'
-                    : 'bg-white border-main-300 text-main-400 hover:bg-main-100 hover:text-main-600'
+                flex items-center justify-center w-10 h-10 rounded-full transition-all duration-200
+                ${isSaved 
+                    ? 'bg-main-500 text-white hover:bg-main-600' 
+                    : 'bg-gray-100 text-gray-400 hover:bg-gray-200 hover:text-main-500'
                 }
                 ${isToggling ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
-                ${className}
+                hover:outline-none hover:ring-2 hover:ring-main-300 hover:ring-offset-2
             `}
             aria-label={isSaved ? '찜 해제' : '찜하기'}
+            type="button"
         >
-            {isSaved ? (
-                <svg className="w-6 h-6 mx-auto" viewBox="0 0 24 23" fill="currentColor">
-                    <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-                </svg>
-            ) : (
-                <svg className="w-5 h-5 mx-auto" viewBox="0 0 24 23" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-                </svg>
-            )}
+            <Heart 
+                className={`w-5 h-5 transition-transform duration-200 ${
+                    isToggling ? 'scale-90' : 'scale-100'
+                }`}
+                fill={isSaved ? 'currentColor' : 'none'}
+            />
         </button>
     );
 }

--- a/src/components/gatherings/shared/utils/fetchPaginatedGatherings.ts
+++ b/src/components/gatherings/shared/utils/fetchPaginatedGatherings.ts
@@ -1,7 +1,7 @@
 import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
 import { internalClient } from '@/lib/api/clientFetchers';
 import { Gathering } from "@/types/gatherings";
-import { isSameDateForFilter, isGatheringExpired } from '@/components/shared/utils/dateFormats';
+import { isSameDateForFilter } from '@/components/shared/utils/dateFormats';
 
 /**
  * 페이지네이션된 모임 목록 조회
@@ -12,7 +12,6 @@ import { isSameDateForFilter, isGatheringExpired } from '@/components/shared/uti
  * @param filterSavedIds 찜목록 필터링
  * @param sortBy 정렬 기준
  * @param sortOrder 정렬 순서
- * @param excludeExpired 마감된 모임 제외 여부
  */
 export async function fetchPaginatedGatherings(
     page: number,
@@ -22,7 +21,6 @@ export async function fetchPaginatedGatherings(
     filterSavedIds?: string[],
     sortBy: string = 'registrationEnd',
     sortOrder: string = 'desc',
-    excludeExpired: boolean = true
 ): Promise<Gathering[]> {
     try {
         // mainType에 따른 type 파라미터 설정
@@ -66,13 +64,6 @@ export async function fetchPaginatedGatherings(
                 console.error('응답 데이터 형식 오류:', response.data);
                 return [];
             }
-        }
-
-        // 마감된 모임 필터링 추가
-        if (excludeExpired) {
-            gatherings = gatherings.filter((gathering: Gathering) => 
-                !isGatheringExpired(gathering.registrationEnd)
-            );
         }
 
         // 한국 시간 기준 날짜 필터링

--- a/src/components/saved/SavedGatheringUI.tsx
+++ b/src/components/saved/SavedGatheringUI.tsx
@@ -18,7 +18,7 @@ export default function SavedGatheringsClient() {
     const { savedIds } = useToggleSavedGatherings();
 
     // 찜한 모임의 상세 데이터만 별도로 가져오기
-    const { data: allSavedGatherings = [], isLoading } = useQuery({
+    const { data: allSavedGatherings = [] } = useQuery({
         queryKey: ["allSavedGatherings", savedIds], // savedIds 자동 갱신
         queryFn: async () => {
             if (savedIds.length === 0) return [];
@@ -70,39 +70,18 @@ export default function SavedGatheringsClient() {
                 onTypeChange={handleTypeChange}
                 initialMainType={selectedMainType}
                 initialSubType={selectedSubType}
-                showCreateButton={false} // 찜한 모임 페이지에서는 모임 만들기 버튼 숨김
+                showCreateButton={false}
             />
             
             <GatheringsList
                 ssrGatherings={allSavedGatherings}
                 selectedMainType={selectedMainType}
                 selectedSubType={selectedSubType}
-                filters={{ location: '', date: '' }} // 기본 필터 (찜한 모임에서는 위치/날짜 필터 사용 안함)
-                sort={{ sortBy: 'registrationEnd', sortOrder: 'desc' }} // 기본 정렬
-                enableInfiniteScroll={false} // 찜한 모임에서는 무한스크롤 비활성화
-                savedGatheringIds={savedIds} // 찜한 모임 ID 목록 (선택사항)
+                filters={{ location: '', date: '' }}
+                sort={{ sortBy: 'registrationEnd', sortOrder: 'desc' }}
+                enableInfiniteScroll={false}
+                savedGatheringIds={savedIds}
             />
-
-            {/* 찜한 모임이 없는 경우 안내 메시지 */}
-            {!isLoading && savedIds.length === 0 && (
-                <div className="w-full h-[400px] flex flex-col justify-center items-center text-gray-500 font-medium">
-                    <h3 className="text-lg font-semibold mb-2">아직 찜한 모임이 없어요</h3>
-                    <p className="text-sm text-center">
-                        마음에 드는 모임을 찾아서<br />
-                        하트 버튼을 눌러보세요!
-                    </p>
-                </div>
-            )}
-
-            {/* 로딩 상태 */}
-            {isLoading && savedIds.length > 0 && (
-                <div className="w-full h-[200px] flex justify-center items-center">
-                    <div className="flex items-center gap-3">
-                        <div className="w-6 h-6 border-3 border-main-500 border-t-transparent rounded-full animate-spin"></div>
-                        <span className="text-gray-600 font-medium">찜한 모임을 불러오는 중...</span>
-                    </div>
-                </div>
-            )}
         </div>
     );
 }

--- a/src/components/shared/ui/Navbar.tsx
+++ b/src/components/shared/ui/Navbar.tsx
@@ -5,18 +5,25 @@ import { usePathname } from 'next/navigation';
 import { AuthContext } from '@/providers/AuthProvider';
 import { DropdownMenu, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from '@radix-ui/react-dropdown-menu';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import { getSavedGatherings } from '@/components/gatherings/shared/utils/savedGatherings';
 import Image from 'next/image';
 import Link from 'next/link';
+
 
 export default function Navbar() {
     const { token, signOut, userName, userImage } = useContext(AuthContext);
 
     const pathname = usePathname();
 
-    const queryClient = useQueryClient();
-    const savedIds = queryClient.getQueryData<string[]>(['savedGatherings']);
-    const savedCounts = Array.isArray(savedIds) ? savedIds.length : 0;
+    // 찜한 모임 개수
+    const { data: savedIds = [] } = useQuery({
+        queryKey: ['savedGatherings'],
+        queryFn: () => getSavedGatherings(),
+        refetchOnWindowFocus: false,
+    });
+
+    const savedCounts = savedIds.length;
 
     const navLinks = [
         { href: '/gatherings', label: '모임 찾기' },

--- a/src/components/shared/utils/dateFormats.ts
+++ b/src/components/shared/utils/dateFormats.ts
@@ -240,30 +240,7 @@ export const isValidDateTimeValue = (value: DateTimeValue | null): boolean => {
 };
 
 /**
- * 모임이 마감되었는지 확인하는 함수 (새로 추가)
- * @param registrationEnd 마감시간 (ISO string)
- * @returns 마감되었으면 true
- */
-export const isGatheringExpired = (registrationEnd: string | null | undefined): boolean => {
-    if (!registrationEnd) return false;
-    
-    try {
-        const endDate = new Date(registrationEnd);
-        const now = new Date();
-        
-        // 한국 시간으로 정확한 비교
-        const koreanEndDate = toKoreanTime(endDate);
-        const koreanNow = toKoreanTime(now);
-        
-        return koreanEndDate <= koreanNow;
-    } catch (error) {
-        console.error('마감 시간 확인 오류:', error);
-        return false;
-    }
-};
-
-/**
- * 마감시간 계산 (개선된 버전 - DateTimeValue와 isBefore 활용)
+ * 마감시간 계산
  * @param registrationEnd 마감시간 (string 또는 DateTimeValue)
  * @returns 마감시간 계산 결과
  */
@@ -331,7 +308,7 @@ export const getTimeRemaining = (registrationEnd: string | DateTimeValue): strin
 };
 
 /**
- * 수정된 필터링 날짜 비교 함수
+ *  필터링 날짜 비교 함수
  * @param dateTimeString ISO 문자열 또는 날짜 문자열
  * @param targetDate YYYY-MM-DD 형식 문자열
  * @returns 같은 날짜면 true

--- a/src/hooks/api/gatherings/useFetchInfiniteGatherings.ts
+++ b/src/hooks/api/gatherings/useFetchInfiniteGatherings.ts
@@ -16,7 +16,6 @@ import { Gathering } from '@/types/gatherings';
  * @param sortOrder 정렬 순서
  * @param filterSavedIds 찜목록 필터링
  * @param startPage 시작 페이지
- * @param excludeExpired 마감된 모임 제외 여부
  */
 interface UseFetchInfiniteGatheringsProps {
     enabled: boolean;
@@ -27,7 +26,6 @@ interface UseFetchInfiniteGatheringsProps {
     sortOrder?: string;
     filterSavedIds?: string[];
     startPage?: number;
-    excludeExpired?: boolean;
 }
 
 export function useFetchInfiniteGatherings({
@@ -39,7 +37,6 @@ export function useFetchInfiniteGatherings({
     sortOrder = 'desc',
     filterSavedIds,
     startPage = 0,
-    excludeExpired = true
 }: UseFetchInfiniteGatheringsProps) {
     const [infiniteScrollEnabled] = useState(true);
     const [hasTriggeredFirstFetch, setHasTriggeredFirstFetch] = useState(false);
@@ -58,7 +55,6 @@ export function useFetchInfiniteGatherings({
             sortBy,
             sortOrder,
             startPage,
-            excludeExpired,
             filterSavedIds: filterSavedIds?.sort().join(',') || ''
         }
     ];
@@ -82,7 +78,7 @@ export function useFetchInfiniteGatherings({
                 filterSavedIds,
                 sortBy,
                 sortOrder,
-                excludeExpired
+                
             );
         },
         getNextPageParam: (lastPage, allPages) => {


### PR DESCRIPTION
## 📌모임 마감 처리 개선 및 찜하기 기능 강화
### GatheringsList.tsx, GatheringsUI.tsx, SaveToggleButton.tsx, 
### fetchPaginatedGatherings.ts, useFetchInfiniteGatherings.ts
- 마감 모임 제거 로직 제거 및 마감 오버레이 추가
- 찜하기 버튼 UI 변경 및 로그인 검증 추가
- excludeExpired 파라미터 제거
- 무한스크롤 훅에서 불필요한 파라미터 정리

## 📌찜한 모임 페이지
### SavedGatheringUI.tsx, Navbar.tsx
- Navbar에서 찜한 모임 개수 queryClient -> useQuery로 조회 방식 개선(자동 카운트)
- GatheringsList로 빈 목록 처리 및 로딩 메시지 통합

## 📌마감된 모임 계산 관련 코드 정리
### dateFormats.ts
-마감된 모임 제거에 사용했던  isGatheringExpired 함수 제거