### PR TITLE
[refactor] 마이페이지 최종 리팩토링

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,18 +67,6 @@ html {
   --color-button-text: var(--color-white);
   --color-button-disabled: var(--color-gray-400);
   --color-button-hover: var(--color-main-600);
-
-  /* ---- 달램핏, 워케이션 대분류 버튼 텍스트 */
-  --color-button-categories-active: var(--color-gray-900);
-  --color-button-categories: var(--color-gray-400);
-
-  /* ---- 달램핏 소분류 버튼 텍스트, 배경색 */
-  --color-button-type-text: var(--color-white);
-  --color-button-type-bg: var(--color-gray-900);
-
-  /* --- 페이지별 헤딩 */
-  --color-heading: var(--color-gray-900);
-  --color-heading-description: var(--color-gray-700);
 }
 
 @theme inline {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import MyPageUI from '@/components/mypage/MyPageUI';
+import ProfileCard from '@/components/mypage/ProfileCard';
 
 export const metadata: Metadata = {
   title: `마이페이지 | Meet Meet`,
@@ -7,5 +8,15 @@ export const metadata: Metadata = {
 };
 
 export default function MyPage() {
-  return <MyPageUI />;
+  return (
+    <main className="contents-container">
+      <section className="flex flex-col gap-2">
+        <h1 className="pt-10 pb-2 text-2xl font-bold text-gray-700">마이 페이지</h1>
+        <section className="overflow-hidden border-2 border-gray-200 rounded-lg">
+          <ProfileCard />
+        </section>
+        <MyPageUI />
+      </section>
+    </main>
+  );
 }

--- a/src/components/mypage/CreatableReview.tsx
+++ b/src/components/mypage/CreatableReview.tsx
@@ -1,7 +1,7 @@
 import { useGatheringsStore } from '@/store/gatheringsStore';
 import { Gathering } from '@/types/gatherings';
 import dynamic from 'next/dynamic';
-import Image from 'next/image';
+import ImageWithFallback from '../shared/ui/ImageWithFallback';
 
 const GatheringInformation = dynamic(() => import('@/components/mypage/shared/ui/GatheringInformation'), { ssr: false });
 const Button = dynamic(() => import('@/components/shared/ui/Button'), { ssr: false });
@@ -17,12 +17,13 @@ export default function CreatableReview({ gathering, myReviewsTab, userId, onOpe
         >
             {/* 이미지 */}
             <div className="flex-shrink-0">
-                <Image
-                    src={gathering.image ?? ''}
+                <ImageWithFallback
+                    fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1749779026/fallback_thumbnail_ssf66o.avif'
+                    src={gathering.image}
                     alt="모임 이미지"
                     width={1000}
                     height={1000}
-                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
+                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
                 />
             </div>
             {/* 정보 */}
@@ -30,7 +31,7 @@ export default function CreatableReview({ gathering, myReviewsTab, userId, onOpe
                 {myReviewsTab === 0 && (
                     <Button
                         variant='default'
-                        text='리뷰 작성하기'
+                        text='리뷰 남기기'
                         onClick={() => {
                             setCurrentGatheringId(Number(gathering.id))
                             onOpenReviewDialog({ userId, gatheringId: Number(gathering.id) })

--- a/src/components/mypage/CreateReviewDialog.tsx
+++ b/src/components/mypage/CreateReviewDialog.tsx
@@ -24,7 +24,7 @@ export default function CreateReviewDialog({
 }: ReviewDialogProps) {
   const { token } = useContext(AuthContext);
 
-  const [score, setScore] = useState(1);
+  const [score, setScore] = useState(5);
   const [comment, setComment] = useState('');
   const [confirmDialog, setConfirmDialog] = useState<{
     open: boolean;
@@ -42,51 +42,58 @@ export default function CreateReviewDialog({
 
   const openConfirmDialog = (text: string, onConfirm?: () => void) => setConfirmDialog({ open: true, text, onConfirm });
 
-  const handleSubmit = () => createReview({ gatheringId: reviewFormData.gatheringId, score, comment, });
+  const handleSubmit = (e?: React.FormEvent) => {
+    if (e) e.preventDefault();
+    createReview({ gatheringId: reviewFormData.gatheringId, score, comment });
+  };
 
   return (
-    <div className="dialog-background">
+    <section className="dialog-background">
       <div className="w-full max-w-md p-6 rounded-md bg-white shadow-md flex flex-col gap-4">
         <h2 className="text-xl font-semibold">리뷰 남기기</h2>
-        <label className="block">만족스러운 경험이었나요?</label>
-        <div className="flex gap-2">
-          {[1, 2, 3, 4, 5].map((val) => (
-            <button
-              key={val}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <label className="block">만족스러운 경험이었나요?</label>
+          <div className="flex gap-2">
+            {[1, 2, 3, 4, 5].map((val) => (
+              <button
+                key={val}
+                type="button"
+                onClick={() => setScore(val)}
+                className="focus:outline-none cursor-pointer"
+                aria-label={`${val}점`}
+              >
+                <Heart
+                  className={`w-8 h-8 transition-colors ${score >= val ? "text-main-500 fill-main-500" : "text-gray-300"}`}
+                />
+              </button>
+            ))}
+          </div>
+          <label className="block">다른 사람들에게 알려주세요😄</label>
+          <textarea
+            value={comment}
+            onChange={e => setComment(e.target.value)}
+            className="w-full border p-2"
+            required={true}
+          />
+
+          <div className="flex gap-2">
+            <Button
               type="button"
-              onClick={() => setScore(val)}
-              className="focus:outline-none cursor-pointer"
-              aria-label={`${val}점`}
-            >
-              <Heart
-                className={`w-8 h-8 transition-colors ${score >= val ? "text-main-500 fill-main-500" : "text-gray-300"}`}
-              />
-            </button>
-          ))}
-        </div>
-
-        <label className="block">경험에 대해 알려주세요!</label>
-        <textarea
-          value={comment}
-          onChange={e => setComment(e.target.value)}
-          className="w-full border p-2"
-        />
-
-        <div className="flex gap-2">
-          <Button
-            variant='cancel'
-            text='취소'
-            onClick={onClose}
-            customClassName="w-full"
-          />
-          <Button
-            variant='default'
-            text='제출'
-            onClick={handleSubmit}
-            customClassName="w-full"
-          />
-        </div>
+              variant='cancel'
+              text='취소'
+              onClick={onClose}
+              customClassName="w-full"
+            />
+            <Button
+              type="submit"
+              variant='default'
+              text='제출'
+              customClassName="w-full"
+            />
+          </div>
+        </form>
       </div>
+
       <ConfirmDialog
         isOpen={confirmDialog.open}
         text={confirmDialog.text}
@@ -94,6 +101,6 @@ export default function CreateReviewDialog({
         onConfirm={confirmDialog.onConfirm}
         onCallback={() => onClose()}
       />
-    </div>
+    </section>
   );
 }

--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -4,8 +4,8 @@ import { useFetchCreatedGatherings } from '@/hooks/api/mypage/useFetchCreatedGat
 import { useContext } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { getTimeRemaining } from '@/components/shared/utils/dateFormats';
-import Image from 'next/image';
 import dynamic from 'next/dynamic';
+import ImageWithFallback from '../shared/ui/ImageWithFallback';
 
 const LoadingUI = dynamic(() => import('@/components/mypage/shared/ui/LoadingUI'), { ssr: false });
 const GatheringInformation = dynamic(() => import('@/components/mypage/shared/ui/GatheringInformation'), { ssr: false });
@@ -21,12 +21,13 @@ export default function CreatedGatherings() {
     return getTimeRemaining(gathering.registrationEnd) !== '마감됨';
   });
 
+
   if (isLoading) return <LoadingUI />;
   if (error) return <p className="text-center text-red-500">에러: {(error as Error).message}</p>;
   if (!isLoading && !error && gatherings.length === 0) return <p className="text-center text-gray-500">내가 만든 모임이 없어요</p>;
 
   return (
-    <section className='px-4 flex flex-col gap-2'>
+    <section className='flex flex-col gap-2'>
       <div className="flex w-full flex-col gap-4">
         {!isLoading && !error && gatherings.map(gathering => {
           return (
@@ -37,11 +38,12 @@ export default function CreatedGatherings() {
               {/* 좌측 이미지 */}
               <article className='relative'>
                 <DateReminder registrationEnd={gathering?.registrationEnd} />
-                <Image src={gathering?.image}
+                <ImageWithFallback src={gathering?.image}
+                  fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1749779026/fallback_thumbnail_ssf66o.avif'
                   alt='모임 이미지'
                   width={1000}
                   height={1000}
-                  className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
+                  className="w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
                 />
               </article>
 

--- a/src/components/mypage/CreatedReview.tsx
+++ b/src/components/mypage/CreatedReview.tsx
@@ -1,35 +1,36 @@
 import { ReviewItem } from '@/types/reviews';
 import { formatDate, formatTime } from '@/components/shared/utils/dateFormats';
 import { Heart } from 'lucide-react';
-import Image from 'next/image';
+import ImageWithFallback from '../shared/ui/ImageWithFallback';
 
 /** 나의 리뷰 - 작성한 리뷰 */
 export default function CreatedReview({ review }: { review: ReviewItem }) {
     return (
         <section className='flex flex-col sm:flex-row gap-4'>
             <div className="flex-shrink-0">
-                <Image
-                    src={review?.Gathering?.image ?? ''}
+                <ImageWithFallback
+                    fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1749779026/fallback_thumbnail_ssf66o.avif'
+                    src={review.Gathering.image!}
                     alt="모임 이미지"
                     width={1000}
                     height={1000}
-                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
+                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
                 />
             </div>
             <div className="flex flex-col gap-1">
                 <div className='flex items-center gap-1'>
-                    {Array.from({ length: review?.score }).map((_, index) => (
+                    {Array.from({ length: review.score }).map((_, index) => (
                         <Heart key={index} className="w-4 h-4 text-main-500 fill-main-500" />
                     ))}
                 </div>
-                <p className='text-sm sm:text-base'>{review?.comment}</p>
-                <span className="text-sm sm:text-xl font-semibold">{review?.Gathering?.name}</span>
+                <p className='text-sm sm:text-base'>{review.comment}</p>
+                <span className="text-sm sm:text-xl font-semibold">{review.Gathering.name}</span>
                 <div className="flex flex-wrap gap-2 text-xs sm:text-base text-gray-400">
                     <span className={`inline-flex items-center rounded-md`}>
-                        {formatDate(review?.Gathering?.dateTime ?? '')}
+                        {formatDate(review.Gathering.dateTime!)}
                     </span>
                     <span className={`inline-flex items-center rounded-md`}>
-                        {formatTime(review?.Gathering?.dateTime ?? '')}
+                        {formatTime(review.Gathering.dateTime!)}
                     </span>
                 </div>
             </div>

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -7,7 +7,7 @@ import { AuthContext } from '@/providers/AuthProvider';
 import { getTimeRemaining, toKoreanTime } from '@/components/shared/utils/dateFormats';
 import { CheckCircle } from "lucide-react"
 import dynamic from 'next/dynamic';
-import Image from 'next/image';
+import ImageWithFallback from '../shared/ui/ImageWithFallback';
 
 const LoadingUI = dynamic(() => import('@/components/mypage/shared/ui/LoadingUI'), { ssr: false });
 const ConfirmDialog = dynamic(() => import('@/components/shared/ui/ConfirmDialog'), { ssr: false });
@@ -59,16 +59,18 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
       const bRegistrationEnd = b.registrationEnd ? toKoreanTime(b.registrationEnd).getTime() : 0;
       return bRegistrationEnd - aRegistrationEnd;
     }
-    // 완료되지 않은 모임을 먼저 표시
     return a.isCompleted ? 1 : -1;
   });
+
+  const DEACTIVATED_STYLE = 'px-3 py-1 rounded-full bg-slate-200 self-start text-gray-500 text-xs';
+  const ACTIVATED_STYLE = 'px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs'
 
   if (isLoading) return <LoadingUI />;
   if (error && !fetchErrorMessage) return <div className="text-red-500">에러: {error.message}</div>;
   if (gatherings.length === 0 && !error) return <div className="text-gray-500 text-center">참여한 모임이 없습니다</div>;
 
   return (
-    <section className='px-4 flex flex-col gap-2'>
+    <section className='flex flex-col gap-2'>
       {sortedGatherings.map(data => (
         <div
           key={data.id}
@@ -84,11 +86,12 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
           {/* 좌측 */}
           <article className='relative'>
             <DateReminder registrationEnd={data?.registrationEnd} />
-            <Image src={data?.image}
+            <ImageWithFallback src={data?.image}
+              fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1749779026/fallback_thumbnail_ssf66o.avif'
               alt='모임 이미지'
               width={1000}
               height={1000}
-              className="w-[17.5rem] h-[10rem] rounded-xl object-cover"
+              className="w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
             />
           </article>
 
@@ -99,22 +102,22 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
               <div className='flex items-center gap-1'>
                 {/* 마감 완료 및 5명 이상 모집 및 모임 후 '이용 완료' */}
                 {getTimeRemaining(data?.registrationEnd) === '마감됨' && data?.participantCount >= 5 && data?.isCompleted && (
-                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">이용 완료</div>)}
+                  <div className={DEACTIVATED_STYLE}>이용 완료</div>)}
 
                 {/* 마감 미완료 및 모임 전 '이용 예정' */}
                 {getTimeRemaining(data?.registrationEnd) !== '마감됨' && !data?.isCompleted && (
-                  <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs">이용 예정</div>)}
+                  <div className={ACTIVATED_STYLE}>이용 예정</div>)}
 
                 {/* 마감 미완료 및 5명 이상 모집 '개설 확정'  */}
                 {getTimeRemaining(data?.registrationEnd) !== '마감됨' && data?.participantCount >= 5 && (
-                  <div className="px-3 py-1 rounded-full bg-main-200 self-start text-white text-xs flex items-center gap-1">
+                  <div className={`${ACTIVATED_STYLE} flex items-center gap-1`}>
                     <CheckCircle className="w-4 h-4 text-white" />
                     개설 확정
                   </div>)}
 
                 {/* 마감 미완료 및 5명 미만 시 '개설 대기' */}
                 {getTimeRemaining(data?.registrationEnd) !== '마감됨' && data?.participantCount < 5 && (
-                  <div className="px-3 py-1 rounded-full bg-gray-200 self-start text-gray-500 text-xs">개설 대기</div>)}
+                  <div className={DEACTIVATED_STYLE}>개설 대기</div>)}
               </div>
               <GatheringInformation data={data} />
             </div>

--- a/src/components/mypage/MyPageUI.tsx
+++ b/src/components/mypage/MyPageUI.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import dynamic from 'next/dynamic';
 
-const ProfileCard = dynamic(() => import('@/components/mypage/ProfileCard'), { ssr: false });
 const JoinedGatherings = dynamic(() => import('@/components/mypage/JoinedGatherings'), { ssr: false });
 const MyReviews = dynamic(() => import('@/components/mypage/MyReviews'), { ssr: false });
 const CreatedGatherings = dynamic(() => import('@/components/mypage/CreatedGatherings'), { ssr: false });
@@ -16,52 +15,44 @@ export default function MyPageUI() {
   const [reviewableGathering, setReviewableGathering] = useState<{ userId: number; gatheringId: number } | null>();
 
   return (
-    <main className="contents-container">
-      <section className="pt-10 px-6 flex flex-col gap-4">
-        <h1 className="text-2xl font-bold text-gray-700">마이 페이지</h1>
-
-        {/* 프로필 카드 */}
-        <ProfileCard />
-
-        <section>
-          {/* 탭 네비게이션 */}
-          <section className="sm:px-4 py-4 flex gap-4 justify-between sm:justify-start text-sm sm:text-lg font-bold">
-            {[
-              { label: "참여중인 모임", value: 0 },
-              { label: "나의 리뷰", value: 1 },
-              { label: "내가 만든 모임", value: 2 },
-            ].map(({ label, value }) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setSelectedTab(value)}
-                className={`relative pb-2 cursor-pointer transition-colors duration-150
-                  ${selectedTab === value
-                    ? "text-gray-800 after:absolute after:-bottom-0.5 after:left-0 after:right-0 after:h-[2px] after:bg-gray-800"
-                    : "text-gray-400"
-                  }`}
-              >
-                {label}
-              </button>
-            ))}
-          </section>
-
-          {selectedTab === 0 &&
-            <JoinedGatherings
-              setSelectedTab={setSelectedTab}
-              setMyReviewsTab={setMyReviewsTab}
-              onOpenReviewDialog={setReviewableGathering}
-            />}
-
-          {selectedTab === 1 &&
-            <MyReviews
-              myReviewsTab={myReviewsTab}
-              setMyReviewsTab={setMyReviewsTab}
-              onOpenReviewDialog={setReviewableGathering}
-            />}
-          {selectedTab === 2 && <CreatedGatherings />}
-        </section>
+    <>
+      {/* 버튼바 */}
+      <section className="relative py-4 flex gap-4 justify-between sm:justify-start text-sm sm:text-lg font-bold">
+        {[
+          { label: "참여중인 모임", value: 0 },
+          { label: "나의 리뷰", value: 1 },
+          { label: "내가 만든 모임", value: 2 },
+        ].map(({ label, value }) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setSelectedTab(value)}
+            className={`cursor-pointer transition-colors duration-150 ${selectedTab === value ? "text-gray-800" : "text-slate-400"}`}
+          >
+            {label}
+          </button>
+        ))}
+        <div
+          className="absolute bottom-0 left-0 h-1 rounded-full bg-gray-800 transition-transform duration-300"
+        />
       </section>
+
+      {/* 컨텐츠 */}
+      {selectedTab === 0 &&
+        <JoinedGatherings
+          setSelectedTab={setSelectedTab}
+          setMyReviewsTab={setMyReviewsTab}
+          onOpenReviewDialog={setReviewableGathering}
+        />}
+
+      {selectedTab === 1 &&
+        <MyReviews
+          myReviewsTab={myReviewsTab}
+          setMyReviewsTab={setMyReviewsTab}
+          onOpenReviewDialog={setReviewableGathering}
+        />}
+
+      {selectedTab === 2 && <CreatedGatherings />}
 
       {
         reviewableGathering && (
@@ -71,6 +62,6 @@ export default function MyPageUI() {
           />
         )
       }
-    </main >
+    </>
   );
 }

--- a/src/components/mypage/MyReviews.tsx
+++ b/src/components/mypage/MyReviews.tsx
@@ -34,25 +34,25 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
   // 작성한 리뷰 (작성한 모임의 ID와 유저 ID를 통해 조회)
   const { data: createdReviews } = useFetchMyCreatedReviews(token!, reviewedGatherings.map(gathering => gathering.id), userId);
 
+  const FILTER_BUTTON_STYLE = 'shadow-sm text-gray-700 text-sm hover:bg-main-apricot'
+
   return (
-    <section className="px-4 flex w-full flex-col justify-start gap-5">
+    <section className="flex w-full flex-col justify-start gap-4">
       <div className="flex justify-center sm:justify-start items-center gap-2">
-        {/* 작성 가능한 리뷰, 작성한 리뷰 버튼 */}
         <Button
           variant='default'
           text='작성 가능한 리뷰'
           onClick={() => setMyReviewsTab(0)}
-          customClassName={`rounded-lg px-4 py-2 text-sm ${myReviewsTab === 0 ? 'bg-gray-700 text-white' : 'bg-gray-100 text-gray-700'} hover:text-white`}
+          customClassName={`${myReviewsTab === 0 ? 'bg-main-apricot' : 'bg-slate-100'} ${FILTER_BUTTON_STYLE}`}
         />
         <Button
           variant='default'
           text='작성한 리뷰'
           onClick={() => setMyReviewsTab(1)}
-          customClassName={`rounded-lg px-4 py-2 text-sm ${myReviewsTab === 1 ? 'bg-gray-700 text-white' : 'bg-gray-100 text-gray-700'} hover:text-white`}
+          customClassName={`${myReviewsTab === 1 ? 'bg-main-apricot' : 'bg-slate-100'} ${FILTER_BUTTON_STYLE}`}
         />
       </div>
 
-      {/* 리뷰 */}
       {myReviewsTab === 0 ? (
         !reviewableGatherings || reviewableGatherings.length === 0 ?
           <span className="text-gray-500 text-center">작성 가능한 리뷰가 없어요</span>

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -15,10 +15,10 @@ export default function ProfileCard() {
   const [isProfileEditDialogOpen, setIsProfileEditDialogOpen] = useState(false);
 
   return (
-    <section className="overflow-hidden border-2 border-gray-200 rounded-lg">
+    <>
       {/* 배경 헤더 */}
       <section className="bg-main-350 relative px-4 py-6">
-        <div className="mb-1 text-sm sm:text-base md:text-lg font-bold text-white">내 프로필</div>
+        <div className="mb-1 text-sm sm:text-base md:text-lg font-bold text-white">PROFILE</div>
         <div className="absolute top-4 right-4">
           <button type="button" onClick={() => setIsProfileEditDialogOpen(true)} className='size-8 sm:size-10 rounded-full flex items-center justify-center hover-button'>
             <SquarePen className="text-white" />
@@ -40,19 +40,19 @@ export default function ProfileCard() {
         </div>
         {/* 스펙 */}
         <div>
-          <div className="text-sm sm:text-md font-bold text-main-500">{userName}</div>
+          <span className="text-sm sm:text-md font-bold text-main-500">{userName}</span>
           <div className="flex gap-2 text-sm text-gray-800">
-            <div className="text-xs sm:text-base font-bold">COMPANY</div>
-            <div className='text-xs sm:text-base'>{userCompanyName}</div>
+            <span className="text-xs sm:text-base font-bold">COMPANY</span>
+            <span className='text-xs sm:text-base'>{userCompanyName}</span>
           </div>
           <div className="flex gap-2 text-gray-800 text-xs sm:text-base">
-            <div className="font-bold">E-MAIL</div>
-            <div>{userEmail}</div>
+            <span className="font-bold">E-MAIL</span>
+            <span>{userEmail}</span>
           </div>
         </div>
       </section>
 
       {isProfileEditDialogOpen && <ProfileEditDialog setIsProfileEditDialogOpen={setIsProfileEditDialogOpen} />}
-    </section>
+    </>
   );
 }

--- a/src/components/mypage/shared/ui/GatheringInformation.tsx
+++ b/src/components/mypage/shared/ui/GatheringInformation.tsx
@@ -31,4 +31,3 @@ export default function GatheringInformation({ data, children }: { data: Gatheri
         </div>
     );
 }
-

--- a/src/components/shared/ui/ImageWithFallback.tsx
+++ b/src/components/shared/ui/ImageWithFallback.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+
+interface ImageWithFallbackProps {
+    src: string;
+    fallbackSrc: string;
+    alt: string;
+    width: number;
+    height: number;
+    className?: string;
+}
+
+export default function ImageWithFallback(props: ImageWithFallbackProps) {
+    const { src, fallbackSrc, alt, width, height, className, ...rest } = props;
+
+    const [imgSrc, setImgSrc] = useState(src);
+
+    return (
+        <Image
+            {...rest}
+            src={imgSrc}
+            alt={alt}
+            onError={() => {
+                console.log('이미지 로드 실패, fallback 이미지 적용');
+                setImgSrc(fallbackSrc)
+            }}
+            width={width}
+            height={height}
+            className={className}
+        />
+    );
+};


### PR DESCRIPTION
## 📌 분리 가능한 정적 컨텐츠는 페이지 컴포넌트에서 렌더링
• main, section, h1
• ProfileCard도 MyPageUI에서 분리하여 page.tsx에서 바로 렌더

## 📌 각 컨텐츠 컴포넌트의 최상위 태그 `px-4` 삭제
• 좌우 패딩이 레이아웃의 어색함 유발

## 📌 각 컨텐츠 컴포넌트의 반복되는 Tailwind 스타일 코드는 상수화
• DEACTIVATED_STYLE, ACTIVATED_STYLE 등 Screaming_Snake_Case 사용

## 📌 작성 가능한 리뷰, 작성한 리뷰 버튼은 모임 찾기의 서브 필터와 스타일 동일하게 변경
• main-apricot 활성화 된 상태일 때 배경색

## 📌 ImageWithFallback 컴포넌트 생성 -> onError 적용된 이미지 사용
• 이미지 에러시 로깅 & 기본 이미지 적용