### PR TITLE
[refactor] 랜딩, 로그인, 회원가입, 프로필 업데이트 페이지 반응형 리팩토링

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -9,10 +9,10 @@ export const metadata: Metadata = {
 
 export default function SignInPage() {
     return (
-        <main className='w-full h-full py-20 flex flex-col lg:flex-row items-center justify-center gap-0 lg:gap-20'>
+        <main className="w-full h-full px-4 sm:px-0 py-20 flex flex-col lg:flex-row items-center justify-center gap-4 lg:gap-20">
             <AuthPoster />
-            <section className='w-[24rem] md:w-[31rem] py-4 rounded-lg shadow-md bg-white dark:bg-dark-2 flex flex-col items-center justify-center'>
-                <h1 className='text-2xl font-bold text-center dark:text-white'>로그인</h1>
+            <section className="w-[20rem] md:w-[31rem] px-6 sm:px-0 py-4 rounded-lg shadow-md border bg-white dark:bg-dark-2 flex flex-col items-center justify-center">
+                <h1 className="text-2xl font-bold text-center dark:text-white">로그인</h1>
                 <SignInForm />
             </section>
         </main>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -9,9 +9,9 @@ export const metadata: Metadata = {
 
 export default function SignUpPage() {
     return (
-        <main className='w-full h-full py-20 flex flex-col lg:flex-row items-center justify-center gap-0 lg:gap-20'>
+        <main className="w-full h-full px-4 sm:px-0 py-20 flex flex-col lg:flex-row items-center justify-center gap-4 lg:gap-20">
             <AuthPoster />
-            <section className='w-[24rem] md:w-[31rem] py-4 rounded-lg shadow-md bg-white dark:bg-dark-2 flex flex-col items-center justify-center'>
+            <section className="w-[20rem] md:w-[31rem] px-6 sm:px-0 py-4 rounded-lg shadow-md border bg-white dark:bg-dark-2 flex flex-col items-center justify-center">
                 <h1 className='text-2xl font-bold text-center dark:text-white'>회원가입</h1>
                 <SignUpForm />
             </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,8 +9,8 @@ html {
 
 @theme {
   /* 브레이크 포인트 */
-  --breakpoint-sm: 376px;
-  --breakpoint-md: 745px;
+  --breakpoint-sm: 401px;
+  --breakpoint-md: 801px;
   --breakpoint-lg: 1101px;
 
   /* 폰트 */
@@ -186,7 +186,7 @@ html {
 
   /* 페이지의 컨텐츠 컨테이너 */
   .contents-container {
-    @apply max-w-screen-lg min-h-screen h-full mx-auto sm:px-4 md:px-20 pt-2 md:pt-8 pb-4 md:pb-10 dark:bg-dark flex flex-col gap-4 dark:text-gray-100;
+    @apply max-w-screen-lg min-h-screen h-full mx-auto px-4 md:px-20 pt-2 md:pt-8 pb-4 md:pb-10 dark:bg-dark flex flex-col gap-4 dark:text-gray-100;
   }
 
   /* 버튼 padding */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import ImageWithFallback from '@/components/shared/ImageWithFallback';
 import { EXTERNAL_PATHS } from '@/lib/api/apiPaths';
 import { serverFetcher } from '@/lib/api/serverFetcher';
 import { Gathering } from '@/types/gatherings';
@@ -7,8 +8,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: `Meet Meet - 특별한 만남`,
-  description: `Meet Meet 홈페이지 입니다.`,
+  title: 'Meet Meet - 특별한 만남',
+  description: 'Meet Meet 홈페이지 입니다.',
 };
 
 interface FeatureCardProps {
@@ -28,7 +29,6 @@ interface GatheringCardProps {
 }
 
 const SOCIAL_PROOF_STYLE = `size-10 rounded-full border-2 border-white flex items-center justify-center`;
-const FLOATING_ELEMENT_STYLE = `absolute top-4 right-4 size-16 rounded-full flex items-center justify-center shadow-lg animate-bounce`;
 const FOOTER_TEXT_BUTTON_STYLE = `hover:text-white transition-colors`;
 
 const GATHERING_TYPES = [
@@ -90,18 +90,24 @@ const GatheringCard = ({
   participants,
   image
 }: GatheringCardProps) => (
-  <Link href={link} className="group p-6 rounded-2xl shadow-sm border border-gray-100 bg-white hover:shadow-md hover:border-main-300 transition-all">
+  <Link href={link} className="group p-6 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-300 bg-white dark:bg-dark-2 hover:shadow-md hover:border-main-300 dark:hover:border-main-400 transition-all">
     <div className="space-y-4">
       {/* 모임 썸네일 위치 */}
-      <Image src={image} alt={title} width={300} height={128} className="w-full h-32 object-cover rounded-xl pointer-events-none" />
+      <ImageWithFallback
+        src={image}
+        fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
+        alt={title}
+        width={300}
+        height={128}
+        className="w-full h-32 object-cover rounded-xl pointer-events-none" />
       <div className="space-y-2">
-        <h3 className="font-semibold group-hover:text-main-500 transition-all">{title}</h3>
-        <p className="text-sm text-gray-500">{schedule}</p>
+        <h3 className="font-semibold group-hover:text-main-500 dark:text-white dark:group-hover:text-main-500 transition-all">{title}</h3>
+        <p className="text-sm text-gray-500 dark:text-white">{schedule}</p>
         <div className="flex items-center gap-2">
           <span className={`px-2 py-1 rounded-full bg-main-400 text-xs text-white`}>
             {category}
           </span>
-          <span className="text-sm text-gray-500"><span className='font-semibold text-main-500'>{participants}</span>명 참여</span>
+          <span className="text-sm text-gray-500 dark:text-white"><span className='font-semibold text-main-500'>{participants}</span>명 참여</span>
         </div>
       </div>
     </div>
@@ -115,7 +121,7 @@ export default async function MainPage() {
     // 색상 경계를 없애기 위해 
     <main className="bg-transparent contents-container">
       {/* Hero Section */}
-      <section className="flex-1 flex flex-col lg:flex-row items-center gap-12 px-6 py-12">
+      <header className="flex-1 flex flex-col lg:flex-row items-center gap-12 px-6 py-12">
         <div className="flex-1 space-y-8">
           <div className="space-y-4">
             <h1 className="text-2xl sm:text-5xl lg:text-6xl font-bold leading-tight">
@@ -167,14 +173,14 @@ export default async function MainPage() {
               className="w-2/3 mx-auto pointer-events-none" />
           </div>
           {/* Floating Elements */}
-          <div className={`${FLOATING_ELEMENT_STYLE} bg-[#F6D55C]`}>
+          <div className="absolute top-4 right-4 w-16 h-16 bg-[#F6D55C] rounded-full flex items-center justify-center shadow-lg animate-bounce">
             <span className="text-2xl">💛</span>
           </div>
-          <div className={`${FLOATING_ELEMENT_STYLE} bg-[#6EE7B7]`}>
+          <div className="absolute bottom-8 left-4 w-12 h-12 bg-[#6EE7B7] rounded-full flex items-center justify-center shadow-lg animate-bounce">
             <span className="text-xl">🌟</span>
           </div>
         </div>
-      </section>
+      </header>
 
       {/* 피쳐 */}
       <section
@@ -190,7 +196,7 @@ export default async function MainPage() {
           </p>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-8">
+        <article className="grid md:grid-cols-3 gap-8">
           <FeatureCard
             icon="👥"
             title="북적북적/도란도란"
@@ -209,7 +215,7 @@ export default async function MainPage() {
             description="실제 이용자들이 남긴 리뷰로 모임의 소감을 알 수 있어요"
             gradient="bg-gradient-to-r from-main-pink to-main-500"
           />
-        </div>
+        </article>
       </section>
 
       {/* 지금 핫한 모임 */}
@@ -220,7 +226,7 @@ export default async function MainPage() {
         <div className="space-y-12">
           <div className="text-center space-y-4">
             <h2 className="text-4xl font-bold dark:text-white">
-              지금 <span className="bg-gradient-to-r from-main-apricot to-[#F472B6] bg-clip-text text-transparent">HOT한</span> 모임들
+              지금 <span className="bg-gradient-to-r from-main-apricot via-main-pink to-main-500 bg-clip-text text-transparent">HOT한</span> 모임들
             </h2>
             <p className="text-lg text-gray-500 dark:text-white">
               다양한 사람들이 만나고 있는 인기 모임에 참여해보시는 건 어떤가요?
@@ -245,7 +251,7 @@ export default async function MainPage() {
 
           <div className="text-center">
             <Link href="/gatherings" className='inline-block'>
-              <div className="px-8 py-3 rounded-xl shadow-sm hover:shadow-md border border-main-300 bg-button-text text-button font-semibold transition-all">
+              <div className="px-8 py-3 rounded-xl shadow-sm hover:shadow-md border border-main-300 bg-button-text dark:bg-dark-2 hover:bg-button dark:hover:bg-button text-button hover:text-button-text font-semibold transition-all">
                 더 많은 모임 보기
               </div>
             </Link>
@@ -296,7 +302,7 @@ export default async function MainPage() {
             <h3 className="font-semibold">팔로우</h3>
             <div className="flex gap-3">
               <a href="https://www.github.com/window-ook/meet-meet" target="_blank">
-                <div title='Github 링크' className="size-8 bg-main-500 rounded-lg flex items-center justify-center hover:scale-110 transition-transform cursor-pointer">
+                <div title='Github 링크' className="size-8 bg-black border border-slate-600 rounded-lg flex items-center justify-center hover:scale-110 transition-transform cursor-pointer">
                   <Image
                     src="https://res.cloudinary.com/dbvzbdffi/image/upload/v1749972038/github_oqdvnr.svg"
                     alt="깃허브 로고"

--- a/src/components/auth/AuthPoster.tsx
+++ b/src/components/auth/AuthPoster.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 
-const DESCRIPTION_STYLE = 'text-2xs sm:text-sm lg:text-base text-gray-600 dark:text-gray-200';
+const DESCRIPTION_STYLE = 'text-sm lg:text-base text-gray-600 dark:text-gray-200';
 
 /** 로그인 폼, 회원가입 폼 배경 이미지 */
 export default function AuthPoster() {
@@ -15,7 +15,7 @@ export default function AuthPoster() {
                 sizes="(max-width: 500px) 300px, (max-width: 700px) 400px, 800px"
                 className='w-[10rem] h-[14rem] md:w-[18rem] md:h-[26rem] lg:w-[22rem] lg:h-[32rem] hover:scale-105 transtion-all duration-200 ease-in-out pointer-events-none'
             />
-            <figcaption>
+            <figcaption className='flex flex-col items-center justify-center'>
                 <h2 className='mb-1 text-lg lg:text-2xl font-bold'>미리 계획하지 않아도 괜찮아요.</h2>
                 <p className={`${DESCRIPTION_STYLE}`}>MeetMeet과 함께라면 언제든지, 어디서든지</p>
                 <p className={`${DESCRIPTION_STYLE}`}>누구와도 의미 있는 만남을 시작할 수 있습니다.</p>

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -62,7 +62,7 @@ export default function SignInForm() {
                 label="이메일"
                 id="email"
                 type="email"
-                placeholder="이메일을 입력해 주세요"
+                placeholder="이메일 입력"
                 {...register('email')}
                 disabled={isSubmitted}
                 isError={errors.email?.message}
@@ -71,7 +71,7 @@ export default function SignInForm() {
                 label='비밀번호'
                 id='password'
                 type='password'
-                placeholder='비밀번호를 입력해 주세요'
+                placeholder='비밀번호 입력'
                 {...register('password')}
                 disabled={isSubmitted}
                 handlePasswordVisibility={() => setIsPasswordVisible((v) => !v)}

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -76,7 +76,7 @@ export default function SignUpForm() {
                 label="이름"
                 id="user-name"
                 type="text"
-                placeholder="이름을 입력해 주세요"
+                placeholder="이름 입력"
                 {...register('name')}
                 disabled={isSubmitted}
                 isError={errors.name?.message}
@@ -85,7 +85,7 @@ export default function SignUpForm() {
                 label="이메일"
                 id="email"
                 type="email"
-                placeholder="이메일을 입력해 주세요"
+                placeholder="이메일 입력"
                 {...register('email')}
                 disabled={isSubmitted}
                 isError={errors.email?.message}
@@ -95,7 +95,7 @@ export default function SignUpForm() {
                 label='크루'
                 id='company-name'
                 type='text'
-                placeholder='크루 이름을 입력해 주세요'
+                placeholder='크루 이름 입력'
                 {...register('companyName')}
                 disabled={isSubmitted}
                 isError={errors.companyName?.message}
@@ -104,7 +104,7 @@ export default function SignUpForm() {
                 label='비밀번호'
                 id='password'
                 type='password'
-                placeholder='비밀번호를 입력해 주세요'
+                placeholder='비밀번호 입력'
                 {...register('password')}
                 disabled={isSubmitted}
                 handlePasswordVisibility={() => setIsPasswordVisible((v) => !v)}
@@ -123,7 +123,7 @@ export default function SignUpForm() {
                         type={isPasswordCheckVisible ? 'text' : 'password'}
                         id="password-check"
                         className={`w-full rounded-lg bg-gray-50 p-2.5 text-sm border-2 focus:outline-none ${!isPasswordMatch ? 'border-red-600' : 'focus:border-main-300'}`}
-                        placeholder="비밀번호를 다시 한 번 입력해 주세요"
+                        placeholder="비밀번호 다시 입력"
                         onChange={(e) => setPasswordCheck(e.target.value)}
                     />
                     <button

--- a/src/components/shared/ProfileEditDialog.tsx
+++ b/src/components/shared/ProfileEditDialog.tsx
@@ -124,13 +124,13 @@ export default function ProfileEditDialog({ setIsProfileEditDialogOpen }: { setI
         >
             <h1 className='text-2xl font-semibold text-white'>PROFILE EDIT</h1>
             <form
-                className="w-full max-w-md p-6 rounded-md bg-white shadow-md flex flex-col gap-4"
+                className="w-full max-w-md p-6 rounded-md bg-white dark:bg-dark-2 shadow-md flex flex-col gap-4"
                 onSubmit={handleSubmit(onSubmit)}
                 aria-labelledby="profile-edit-title"
             >
                 <h2 id="profile-edit-title" className="sr-only">프로필 수정</h2>
                 <div className="grid grid-cols-3 items-center gap-y-6 gap-x-4 w-full mb-2">
-                    <label htmlFor="profile-image" className="col-span-1 text-left font-semibold">IMAGE (1:1)</label>
+                    <label htmlFor="profile-image" className="col-span-1 text-left text-global-text dark:text-white font-semibold">IMAGE (1:1)</label>
                     <div className="col-span-2 flex items-center gap-4">
                         <Button
                             variant='cancel'

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -170,6 +170,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
         if (isLoading) return; // 로딩 중이면 아무것도 하지 않음
         if (!token && pathname === '/mypage') setSignInDialogOpen(true); // 마이페이지: 로그인 필요
         if (!token && pathname === '/saved') setSignInDialogOpen(true); // 찜한 모임: 로그인 필요
+        if (!token && pathname === '/auth/profile') setSignInDialogOpen(true); // 프로필 수정: 로그인 필요
         if (!pathname.includes('/auth')) setPreviousPath(pathname); // 로그인 후 이전 경로 저장
         if (token && pathname === '/auth/signin') router.replace(previousPath); // 로그인: 로그인 되어있는 경우, 이전 경로로 이동
         if (token && pathname === '/auth/signup') router.replace('/'); // 회원가입: 로그인 되어있는 경우, 메인페이지로 이동(이건 직접 주소 입력으로 뚫고 들어오는 경우 때문에 추가)


### PR DESCRIPTION
## 📌 global.css
• 브레이크 포인트 수정: sm 401, md 801, lg 1101
• contents-container: px-4를 기본으로, sm 이하 조건 삭제

## 📌 랜딩페이지
• 다크모드 미적용된 '지금 HOT한 모임' 카드에 다크 모드 적용
• 히어로 섹션에 겹쳐있던 바운스 요소 다시 롤백
• 깃허브 아이콘 디폴트로 변경

## 📌 로그인
• 반응형 수정
• placeholder 간소화

## 📌 회원가입
• 반응형 수정
• placeholder 간소화

## 📌 AuthProvider
• 프로필 업데이트 비로그인 접근 방지 추가

## 📌 프로필 업데이트 페이지
• 다크모드 적용