### PR TITLE
[refactor] 마이페이지 반응형 리팩토링, 리뷰 생성시 ‘모든 리뷰’ 업데이트 관련 문제 해결중

### DIFF
--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -43,7 +43,7 @@ export default function CreatedGatherings() {
                 alt='모임 썸네일'
                 width={1000}
                 height={1000}
-                className="w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
+                className="w-full sm:w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
               />
             </div>
 

--- a/src/components/mypage/CreatedReview.tsx
+++ b/src/components/mypage/CreatedReview.tsx
@@ -14,7 +14,7 @@ export default function CreatedReview({ review }: { review: ReviewItem }) {
                     alt="모임 썸네일"
                     width={1000}
                     height={1000}
-                    className="w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
+                    className="w-full sm:w-[17.5rem] h-[10rem] rounded-xl object-cover pointer-events-none"
                 />
             </div>
             <div className="flex flex-col gap-1">

--- a/src/components/mypage/GatheringInformation.tsx
+++ b/src/components/mypage/GatheringInformation.tsx
@@ -9,7 +9,7 @@ export default function GatheringInformation({ data, children }: { data: Gatheri
         <article className='flex flex-col gap-2 sm:gap-1 justify-between'>
             <div className='flex flex-col gap-2 sm:gap-1'>
                 {/* 모임 이름  */}
-                <span className="text-lg sm:text-xl font-semibold">{data?.name}</span>
+                <span className="text-base sm:text-lg font-semibold">{data?.name}</span>
                 {/* 장소  */}
                 <span className="text-sm sm:text-base text-gray-600 dark:text-white">{data?.location}</span>
             </div>

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -136,7 +136,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                         setSelectedTab(1);
                         setMyReviewsTab(1);
                       }}
-                      customClassName='w-24 sm:w-36'
+                      customClassName='w-24 sm:w-36 text-sm md:text-base'
                     />
                   ) : (
                     // 리뷰 작성 미완료 
@@ -144,7 +144,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                       variant='default'
                       text='리뷰 남기기'
                       onClick={() => onOpenReviewDialog({ userId, gatheringId: Number(data.id) })}
-                      customClassName='w-28 sm:w-32'
+                      customClassName='w-28 sm:w-32 text-sm md:text-base'
                     />
                   )}
                 </div>
@@ -155,7 +155,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
                 variant='cancel'
                 text='참여 취소하기'
                 onClick={() => leaveGathering(Number(data?.id))}
-                customClassName='w-28 sm:w-32'
+                customClassName='w-28 sm:w-32 text-sm md:text-base'
               />
             </div>
           </article>

--- a/src/components/reviews/ReviewsList.tsx
+++ b/src/components/reviews/ReviewsList.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { ReviewItem } from '@/types/reviews';
 import { useFetchInfiniteReviews } from '@/hooks/api/reviews/useFetchInfiniteReviews';
 import { isSameDateForFilter } from '@/utils/shared/date';
+import { decodeHtmlEntities } from '@/utils/shared/decodeHtmlEntities';
 import ReviewStats from '@/components/reviews/ReviewStats';
 import ImageWithFallback from '@/components/shared/ImageWithFallback';
 import HeartRating from '@/components/reviews/HeartRating';
@@ -211,7 +212,7 @@ export default function ReviewsList({
                                     {/* 평점 */}
                                     <HeartRating score={review.score} />
                                     {/* 리뷰 내용 */}
-                                    <p className="text-sm text-gray-700 mt-2 mb-3 dark:text-white">{review.comment}</p>
+                                    <p className="text-sm text-gray-700 mt-2 mb-3 dark:text-white">{decodeHtmlEntities(review.comment)}</p>
                                     {/* 모임 정보 */}
                                     <div className="space-y-1">
                                         <p className={TEXT_GRAY_XS_STYLES}>

--- a/src/hooks/api/mypage/useCreateReview.ts
+++ b/src/hooks/api/mypage/useCreateReview.ts
@@ -9,6 +9,7 @@ import { AxiosError } from 'axios';
 import { isErrorResponse } from '@/lib/api/surfGuard';
 import { myPageQuery } from '@/queries/mypage.query';
 import { gatheringDetailQuery } from '@/queries/gatherings.query';
+import { reviewsQuery } from '@/queries/review.query';
 
 interface CreateReviewParams {
     gatheringId: number;
@@ -33,9 +34,10 @@ export const useCreateReview = ({ token, onCallback }: GatheringApiParams) => {
             return response.data;
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: myPageQuery.myReviews(token!) });
             queryClient.invalidateQueries({ queryKey: myPageQuery.joinedGatherings(token!) });
+            queryClient.invalidateQueries({ queryKey: myPageQuery.myReviews(token!) });
             queryClient.invalidateQueries({ queryKey: gatheringDetailQuery.reviews(currentGatheringId!) });
+            queryClient.invalidateQueries({ queryKey: reviewsQuery.all() });
             onCallback?.('리뷰가 성공적으로 등록되었습니다');
         },
         onError: (error) => {

--- a/src/hooks/api/reviews/useFetchInfiniteReviews.ts
+++ b/src/hooks/api/reviews/useFetchInfiniteReviews.ts
@@ -48,7 +48,14 @@ export function useFetchInfiniteReviews({
     const normalizedDate = date?.trim() || '';
 
     // 쿼리 키
-    const queryKey = [...reviewsQuery.infinite()];
+    const queryKey = reviewsQuery.infinite(
+        mainType,
+        normalizedLocation,
+        normalizedDate,
+        sortBy,
+        sortOrder,
+        startPage
+    );
 
     // 리뷰 무한스크롤 데이터
     const {

--- a/src/queries/review.query.ts
+++ b/src/queries/review.query.ts
@@ -12,5 +12,5 @@ export const reviewsQuery = {
         sortBy?: string,
         sortOrder?: string,
         startPage?: number
-    ) => [...reviewsQuery.all(), { mainType, location, date, sortBy, sortOrder, startPage }] as const,
+    ) => [...reviewsQuery.all(), 'infinite', { mainType, location, date, sortBy, sortOrder, startPage }] as const,
 }


### PR DESCRIPTION
## 📌 마이페이지 반응형 리팩토링
• sm 미만, md 미만, md 이상 적절하게 요소 크기 재설정

## 📌 리뷰 생성시 ‘모든 리뷰’ 업데이트 관련 문제 해결중
• 리뷰가 생성되면 모임 상세 페이지와 마이페이지의 작성한 리뷰에는 곧바로 반영됨, 하지만 모든 리뷰는 안 됨
• useCreateReview의 `queryClient.invalidateQueries({ queryKey: reviewsQuery.all() });`
• useFetchInfiniteReviews의 쿼리키 수정
```
const queryKey = reviewsQuery.infinite(
    mainType,
    normalizedLocation,
    normalizedDate,
    sortBy,
    sortOrder,
    startPage
);
```
 • 쿼리키 참조는 정상인데 강력 새로고침을 해야만 캐시와 UI 업데이트가 진행됨 -> 필터 로직에 수정이 필요한 것 같음