### PR TITLE
commit3: 리뷰 필터링 및 정렬 로직 개선, 필터링 다크모드 스타일 개선, 리뷰 fetch파일 로직 분할

### DIFF
--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -59,12 +59,14 @@ async function getFilteredReviews(searchParams: {
             params.set('location', location.trim());
         }
 
-        // 날짜 필터
+        // 날짜 필터 (서버에서 처리)
         if (date?.trim() && DATE_REGEX_PATTERN.test(date.trim())) {
             params.set('date', date.trim());
         }
 
-        const data = await serverFetcher<Reviews>(`${EXTERNAL_PATHS.REVIEWS}?${params.toString()}`, { cache: 'force-cache' });
+        const data = await serverFetcher<Reviews>(`${EXTERNAL_PATHS.REVIEWS}?${params.toString()}`, { 
+            cache: 'no-store'
+        });
 
         // 응답 데이터 구조 확인
         let reviews: ReviewItem[] = [];
@@ -77,21 +79,7 @@ async function getFilteredReviews(searchParams: {
             return [];
         }
 
-        if (Array.isArray(reviews)) {
-            // DALLAEMFIT의 경우 서브타입 필터링
-            if (mainType === 'DALLAEMFIT') {
-                return reviews.filter((review: ReviewItem) =>
-                    review.Gathering && (
-                        review.Gathering.type === 'OFFICE_STRETCHING' ||
-                        review.Gathering.type === 'MINDFULNESS'
-                    )
-                );
-            }
-            return reviews;
-        } else {
-            console.warn('data가 배열이 아닙니다:', reviews);
-            return [];
-        }
+        return reviews;
 
     } catch (error) {
         console.error('리뷰 SSR 에러:', error);

--- a/src/components/reviews/ReviewsList.tsx
+++ b/src/components/reviews/ReviewsList.tsx
@@ -3,7 +3,6 @@
 import { useMemo } from 'react';
 import { ReviewItem } from '@/types/reviews';
 import { useFetchInfiniteReviews } from '@/hooks/api/reviews/useFetchInfiniteReviews';
-import { isSameDateForFilter } from '@/utils/shared/date';
 import { decodeHtmlEntities } from '@/utils/shared/decodeHtmlEntities';
 import ReviewStats from '@/components/reviews/ReviewStats';
 import ImageWithFallback from '@/components/shared/ImageWithFallback';
@@ -14,12 +13,6 @@ const TEXT_GRAY_XS_STYLES = "text-xs text-gray-400";
 
 /**
  * 리뷰 목록 프로퍼티
- * @param ssrReviews 서버 렌더링 리뷰 목록
- * @param selectedMainType 선택된 모임 주제
- * @param selectedSubType 선택된 모임 서브타입
- * @param filters 필터 옵션
- * @param sort 정렬 옵션
- * @param enableInfiniteScroll 무한스크롤 활성화 여부
  */
 interface ReviewsListProps {
     ssrReviews: ReviewItem[];
@@ -38,53 +31,39 @@ interface ReviewsListProps {
 }
 
 /**
- * 리뷰 타입 필터링 (클라이언트 사이드)
- * @param reviewsList 리뷰 목록
- * @param selectedMainType 선택된 메인 타입
- * @param selectedSubType 선택된 서브 타입
- * @returns 필터링된 리뷰 목록
+ * 리뷰 타입 필터링
  */
 const filterReviewsByType = (
     reviewsList: ReviewItem[],
     selectedMainType: string,
     selectedSubType: string
 ): ReviewItem[] => {
-
     if (selectedMainType === 'DORANDORAN') {
-        const result = reviewsList.filter(review =>
+        return reviewsList.filter(review =>
             review.Gathering && review.Gathering.type === 'WORKATION'
         );
-        return result;
     } else {
         if (selectedSubType === 'ALL') {
-            const result = reviewsList.filter(review =>
+            return reviewsList.filter(review =>
                 review.Gathering && (
                     review.Gathering.type === 'OFFICE_STRETCHING' ||
                     review.Gathering.type === 'MINDFULNESS'
                 )
             );
-
-            return result;
         } else {
-            const result = reviewsList.filter(review =>
+            return reviewsList.filter(review =>
                 review.Gathering && review.Gathering.type === selectedSubType
             );
-            return result;
         }
     }
 };
 
 /**
  * 리뷰 위치/날짜 필터링 함수
- * @param reviewsList 리뷰 목록
- * @param location 위치
- * @param date 날짜
- * @returns 필터링된 리뷰 목록
  */
 const filterReviewsByLocationAndDate = (
     reviewsList: ReviewItem[],
-    location: string,
-    date: string
+    location: string
 ): ReviewItem[] => {
     return reviewsList.filter(review => {
         // 위치 필터 (모임 위치 기준)
@@ -92,35 +71,23 @@ const filterReviewsByLocationAndDate = (
             return false;
         }
 
-        // 날짜 필터 (모임 개최일 기준)
-        if (date && review.Gathering?.dateTime) {
-            if (!isSameDateForFilter(review.Gathering.dateTime, date)) {
-                return false;
-            }
-        }
-
+        // 날짜 필터는 서버에서 처리하므로 클라이언트에서는 제거
         return true;
     });
 };
 
 /**
  * 중복 제거 함수
- * @param reviews 리뷰 목록
- * @returns 중복 제거된 리뷰 목록
  */
 const removeDuplicateReviews = (reviews: ReviewItem[]): ReviewItem[] => {
     const seen = new Set<string>();
-    const duplicates: ReviewItem[] = [];
-
-    const result = reviews.filter(review => {
+    return reviews.filter(review => {
         if (seen.has(review.id)) {
-            duplicates.push(review);
             return false;
         }
         seen.add(review.id);
         return true;
     });
-    return result;
 };
 
 export default function ReviewsList({
@@ -148,31 +115,19 @@ export default function ReviewsList({
         sortOrder: sort.sortOrder
     });
 
-    // SSR 데이터 타입 및 위치/날짜 필터링
-    const filteredSSRReviews = useMemo(() => {
-        // 1. 타입 필터링
-        const typeFiltered = filterReviewsByType(ssrReviews, selectedMainType, selectedSubType);
-
-        // 2. 위치/날짜 필터링
-        const locationDateFiltered = filterReviewsByLocationAndDate(typeFiltered, filters.location, filters.date);
-
-        return locationDateFiltered;
-    }, [ssrReviews, selectedMainType, selectedSubType, filters]);
-
-    // CSR 데이터 타입 필터링
-    const filteredCSRReviews = useMemo(() => {
-        const result = filterReviewsByType(infiniteReviews, selectedMainType, selectedSubType);
-
-        return result;
-    }, [infiniteReviews, selectedMainType, selectedSubType]);
-
-    // 중복 제거된 최종 리뷰 목록
+    // 최종 리뷰 목록 처리
     const allReviews = useMemo(() => {
-        const combined = [...filteredSSRReviews, ...filteredCSRReviews];
+        // 1. 서버에서 이미 정렬된 데이터들을 단순 병합
+        const combined = [...ssrReviews, ...infiniteReviews];
         const deduplicated = removeDuplicateReviews(combined);
 
-        return deduplicated;
-    }, [filteredSSRReviews, filteredCSRReviews]);
+        // 2. 타입 필터링만 수행
+        const typeFiltered = filterReviewsByType(deduplicated, selectedMainType, selectedSubType);
+
+        const locationDateFiltered = filterReviewsByLocationAndDate(typeFiltered, filters.location);
+
+        return locationDateFiltered;
+    }, [ssrReviews, infiniteReviews, selectedMainType, selectedSubType, filters]);
 
     // 로딩 상태 계산
     const isLoading = isFilterChanged || (enableInfiniteScroll && status === 'pending');

--- a/src/components/shared/LocationDateFilter.tsx
+++ b/src/components/shared/LocationDateFilter.tsx
@@ -6,7 +6,7 @@ import { ChevronDown, Clock, Timer, Star, Users } from 'lucide-react';
 // 스타일 상수
 const BUTTON_BASE_STYLES = "flex items-center gap-2 padding-button bg-white border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:border-main-300 focus:outline-none focus:ring-2 focus:ring-main-500 focus:border-main-500";
 const DROPDOWN_CONTAINER_STYLES = "absolute top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-50";
-const DROPDOWN_ITEM_BASE_STYLES = "w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150";
+const DROPDOWN_ITEM_BASE_STYLES = "w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-gray-50 dark:bg-dark-2 dark:text-gray-200 dark:hover:bg-gray-700 transition-colors duration-150";
 const SELECTED_INDICATOR_STYLES = "w-2 h-2 bg-main-600 rounded-full mt-1.5 flex-shrink-0";
 
 // 매직넘버 상수

--- a/src/hooks/api/reviews/useFetchInfiniteReviews.ts
+++ b/src/hooks/api/reviews/useFetchInfiniteReviews.ts
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { fetchReviewsPaginated } from '@/utils/reviews/fetch';
+import { fetchReviewsPaginated } from '@/utils/reviews/fetchPaginatedReviews';
 import { ReviewItem } from '@/types/reviews';
 import { reviewsQuery } from '@/queries/review.query';
 

--- a/src/hooks/api/reviews/useFetchInfiniteReviews.ts
+++ b/src/hooks/api/reviews/useFetchInfiniteReviews.ts
@@ -90,7 +90,6 @@ export function useFetchInfiniteReviews({
             return nextPage;
         },
         initialPageParam: startPage,
-        // 스크롤 기반 지연 로딩
         enabled: enabled && infiniteScrollEnabled && hasTriggeredFirstFetch,
         retry: 2,
         refetchOnWindowFocus: false,

--- a/src/utils/reviews/fetch.ts
+++ b/src/utils/reviews/fetch.ts
@@ -1,6 +1,5 @@
 import { internalClient } from "@/lib/api/clientFetchers";
 import { ReviewItem } from "@/types/reviews";
-import { isSameDateForFilter } from '@/utils/shared/date';
 
 // 매직넘버 상수
 const ITEMS_PER_PAGE = 3; // 페이지당 리뷰 개수
@@ -45,6 +44,11 @@ export async function fetchReviewsPaginated(
             params.location = location.trim();
         }
 
+        // 날짜 필터 (서버에서 처리)
+        if (date && date.trim() !== '') {
+            params.date = date.trim();
+        }
+
         // 리뷰 목록 조회
         const response = await internalClient.get('/api/reviews', { params });
 
@@ -62,17 +66,6 @@ export async function fetchReviewsPaginated(
                 console.error('리뷰 응답 데이터 형식 오류:', response.data);
                 return [];
             }
-        }
-
-        // 한국 시간 기준 날짜 필터링
-        if (date && date.trim() !== '') {
-            const targetDate = date.trim();
-
-            reviews = reviews.filter((review: ReviewItem) => {
-                if (!review.Gathering?.dateTime) return false;
-
-                return isSameDateForFilter(review.Gathering.dateTime, targetDate);
-            });
         }
 
         // DALLAEMFIT 서브타입 필터링

--- a/src/utils/reviews/fetchFilterReviews.ts
+++ b/src/utils/reviews/fetchFilterReviews.ts
@@ -1,0 +1,36 @@
+import { ReviewItem } from "@/types/reviews";
+
+/**
+ * 리뷰 타입 필터링
+ * @param reviewsList 리뷰 목록
+ * @param selectedMainType 모임 주제
+ * @param selectedSubType 모임 서브타입
+ * @returns 필터링된 리뷰 목록
+ */
+export const filterReviews = (
+    reviewsList: ReviewItem[],
+    selectedMainType: string,
+    selectedSubType: string
+): ReviewItem[] => {
+    // 도란도란 (WORKATION)
+    if (selectedMainType === 'DORANDORAN') {
+        return reviewsList.filter(review =>
+            review.Gathering && review.Gathering.type === 'WORKATION'
+        );
+    } else {
+        // 북적북적 (DALLAEMFIT)
+        if (selectedSubType === 'ALL' || !selectedSubType) {
+            return reviewsList.filter(review =>
+                review.Gathering && (
+                    review.Gathering.type === 'OFFICE_STRETCHING' ||
+                    review.Gathering.type === 'MINDFULNESS'
+                )
+            );
+        } else {
+            // 특정 서브타입만
+            return reviewsList.filter(review =>
+                review.Gathering && review.Gathering.type === selectedSubType
+            );
+        }
+    }
+};

--- a/src/utils/reviews/fetchPaginatedReviews.ts
+++ b/src/utils/reviews/fetchPaginatedReviews.ts
@@ -91,38 +91,3 @@ export async function fetchReviewsPaginated(
         return [];
     }
 }
-
-/**
- * 리뷰 타입 필터링
- * @param reviewsList 리뷰 목록
- * @param selectedMainType 모임 주제
- * @param selectedSubType 모임 서브타입
- * @returns 필터링된 리뷰 목록
- */
-export const filterReviews = (
-    reviewsList: ReviewItem[],
-    selectedMainType: string,
-    selectedSubType: string
-): ReviewItem[] => {
-    // 도란도란 (WORKATION)
-    if (selectedMainType === 'DORANDORAN') {
-        return reviewsList.filter(review =>
-            review.Gathering && review.Gathering.type === 'WORKATION'
-        );
-    } else {
-        // 북적북적 (DALLAEMFIT)
-        if (selectedSubType === 'ALL' || !selectedSubType) {
-            return reviewsList.filter(review =>
-                review.Gathering && (
-                    review.Gathering.type === 'OFFICE_STRETCHING' ||
-                    review.Gathering.type === 'MINDFULNESS'
-                )
-            );
-        } else {
-            // 특정 서브타입만
-            return reviewsList.filter(review =>
-                review.Gathering && review.Gathering.type === selectedSubType
-            );
-        }
-    }
-};


### PR DESCRIPTION
## 📌 [fix] 리뷰 필터링 및 정렬 로직 개선
### reviews/page.tsx, useFetchInfiniteReviews.ts, ReviewsList.tsx, page.tsx
- 캐시 비활성화로 항상 최신 데이터 보장 ({ cache: 'no-store' } 옵션 추가)
- 불필요한 필터링 로직 제거 (서버에서 처리하도록 통합)
- 서버에서 받은 정렬 순서 유지하도록 수정
- 불필요한 날짜 비교 로직 제거
- 위치 필터링만 클라이언트에서 처리하도록 역할 분담 명확화

## 📌 [style] 필터링 다크모드 스타일 개선
### LocationDateFilter.tsx


## 📌 [refactor] 리뷰 fetch파일 로직 분할
### fetch.ts, fetchFilterReivews.ts, fetchPaginatedReviews.ts
