### PR TITLE
commits2: useQuery 로직 분리, 리뷰 페이지 로딩 상태 개선

### DIFF
--- a/src/components/gatherings/GatheringsList.tsx
+++ b/src/components/gatherings/GatheringsList.tsx
@@ -2,21 +2,24 @@
 
 import { useRouter } from "next/navigation";
 import { useFetchInfiniteGatherings } from "@/hooks/api/gatherings/useFetchInfiniteGatherings";
-import { useMemo } from 'react';
+import { useMemo, useCallback, useTransition, memo } from 'react';
 import { formatDate, formatTime } from '@/utils/shared/date';
 import { Gathering } from "@/types/gatherings";
 import { UserRoundCheck } from "lucide-react";
 import { filterGatheringsByType, getUniqueGatherings } from '@/utils/gatherings/gatheringsUtils';
 import ImageWithFallback from "@/components/shared/ImageWithFallback";
 import JoinedCountsProgressBar from "@/components/gatherings/shared/JoinedCountsProgressBar";
-import SaveToggleButton from '@/components/shared/SaveToggleButton';
 import DateReminder from '@/components/shared/DateReminder';
+import dynamic from 'next/dynamic';
+
+const SaveToggleButton = dynamic(() => import('@/components/shared/SaveToggleButton'), {
+    loading: () => <div className="w-6 h-6 bg-gray-200 rounded animate-pulse" />,
+    ssr: false
+});
 
 // 스타일 상수
 const BADGE_BASE_STYLES = "inline-flex items-center px-3 py-1 text-xs sm:text-sm font-medium rounded-md";
-
-// 매직넘버 상수
-const DEFAULT_TITLE_MAX_LENGTH = 20; // 제목 최대 길이
+const DEFAULT_TITLE_MAX_LENGTH = 20;
 
 interface GatheringsListProps {
     ssrGatherings: Gathering[];
@@ -36,10 +39,125 @@ interface GatheringsListProps {
     isFilterChanged?: boolean;
 }
 
+// 컴포넌트 외부에 함수 선언
 const truncateTitle = (title: string, maxLength: number = DEFAULT_TITLE_MAX_LENGTH): string => {
     if (!title) return '';
     return title.length > maxLength ? title.slice(0, maxLength) + '...' : title;
 };
+
+// 정적 컴포넌트들
+const GatheringBadges = memo(({ dateTime }: { dateTime: string }) => (
+    <div className="flex flex-wrap gap-2 mb-3 -mt-3">
+        <span className={`${BADGE_BASE_STYLES} bg-main-400 text-white dark:bg-main-600 dark:text-gray-100`}>
+            {formatDate(dateTime)}
+        </span>
+        <span className={`${BADGE_BASE_STYLES} border-2 border-main-400 text-main-400 dark:border-main-400 dark:text-main-400 dark:bg-none`}>
+            {formatTime(dateTime)}
+        </span>
+    </div>
+));
+
+const LoadingState = memo(() => (
+    <div className="w-full h-[300px] flex flex-col justify-center items-center text-gray-500 dark:text-gray-400 font-medium text-sm transition-colors duration-200">
+        <div className="flex items-center gap-3 mb-2">
+            <div className="size-6 border-3 border-main-400 dark:border-main-400 border-t-transparent rounded-full animate-spin"></div>
+            <p className="text-lg font-semibold">로딩 중...</p>
+        </div>
+        <p>모임을 불러오고 있어요</p>
+    </div>
+));
+
+const EmptyState = memo(() => (
+    <div className="w-full h-[300px] flex flex-col justify-center items-center text-gray-500 dark:text-gray-400 font-medium text-sm transition-colors duration-200">
+        <p className="text-lg font-semibold mb-2">아직 모임이 없어요</p>
+        <p>곧 새로운 모임이 열릴 예정이에요</p>
+    </div>
+));
+
+const InfiniteScrollLoader = memo(() => (
+    <div className="w-full h-[80px] flex justify-center items-center">
+        <div className="flex items-center gap-3">
+            <div className="size-4 border-3 border-main-400 dark:border-main-400 border-t-transparent rounded-full animate-spin"></div>
+            <span className="text-gray-600 dark:text-gray-400 font-medium transition-colors duration-200">더 많은 모임을 불러오는 중...</span>
+        </div>
+    </div>
+));
+
+// 개별 모임 아이템 컴포넌트 memo로 최적화
+const GatheringItem = memo(({ 
+    gathering, 
+    index, 
+    isLastItem, 
+    lastItemRef,
+    onGatheringClick 
+}: {
+    gathering: Gathering;
+    index: number;
+    isLastItem: boolean;
+    lastItemRef?: (node: HTMLElement | null) => void;
+    onGatheringClick: (id: number) => void;
+}) => (
+    <article
+        role="button"
+        tabIndex={0}
+        key={`${gathering.teamId || 'unknown'}-${gathering.id}-${index}`}
+        onClick={() => onGatheringClick(gathering.id)}
+        ref={isLastItem ? lastItemRef : undefined}
+        className="w-full flex flex-col md:flex-row justify-start border border-gray-200 dark:border-dark-2 dark:bg-dark-2 rounded-2xl bg-white hover:border-main-300 dark:hover:border-main-400 hover:shadow-lg dark:hover:shadow-dark-lg transition-all duration-300 overflow-hidden relative cursor-pointer"
+        aria-label={`${gathering.name} 모임`}
+    >
+        {/* 이미지 영역 */}
+        <div className="w-full md:w-80 h-48 md:h-40 flex-shrink-0 relative">
+            <DateReminder registrationEnd={gathering.registrationEnd} />
+            <ImageWithFallback
+                src={gathering.image}
+                fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
+                alt={`${gathering.name} 모임 썸네일`}
+                width={320}
+                height={180}
+                className="w-full h-full rounded-t-2xl md:rounded-l-2xl md:rounded-t-none object-cover pointer-events-none"
+            />
+        </div>
+
+        <div className="flex-1 flex flex-col justify-between p-4 md:p-6 min-h-0">
+            <div className="flex-1 w-full">
+                <div className="flex flex-row md:justify-between gap-3">
+                    <div className="flex-1 flex flex-row gap-2 items-center">
+                        <h2 className="text-sm sm:text-lg font-semibold -mt-6 text-gray-900 dark:text-gray-100 transition-colors duration-200">
+                            {truncateTitle(gathering.name)}
+                        </h2>
+                        <div className="hidden md:block w-[2px] h-[16px] -mt-6 bg-gray-900 dark:bg-gray-300"></div>
+                        <p className="text-sm font-medium -mt-6 text-gray-700 dark:text-gray-300 transition-colors duration-200">
+                            {gathering.location}
+                        </p>
+                    </div>
+                    <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0">
+                        <SaveToggleButton gatheringId={gathering.id.toString()} />
+                    </div>
+                </div>
+
+                {gathering.dateTime && (
+                    <GatheringBadges dateTime={gathering.dateTime} />
+                )}
+            </div>
+
+            <div className="flex flex-row items-center justify-between">
+                <div className="flex items-center gap-2">
+                    <UserRoundCheck className="size-4 text-main-400 dark:text-main-400" />
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors duration-200">
+                        {gathering.participantCount}/{gathering.capacity}
+                    </span>
+                </div>
+                <div className="w-full px-2">
+                    <JoinedCountsProgressBar
+                        participantCount={gathering.participantCount}
+                        capacity={gathering.capacity}
+                    />
+                </div>
+            </div>
+        </div>
+    </article>
+));
 
 export default function GatheringsList({
     ssrGatherings,
@@ -53,15 +171,14 @@ export default function GatheringsList({
     isFilterChanged = false,
 }: GatheringsListProps) {
     const router = useRouter();
+    const [isPending, startTransition] = useTransition();
     const isSavedPage = savedGatheringIds.length > 0;
 
     const csrStartIndex = useMemo(() => {
         if (ssrGatherings.length === 0) {
             return activeStartIndex;
         }
-
-        const calculatedIndex = activeStartIndex + ssrGatherings.length;
-        return calculatedIndex;
+        return activeStartIndex + ssrGatherings.length;
     }, [activeStartIndex, ssrGatherings.length]);
 
     const {
@@ -84,24 +201,25 @@ export default function GatheringsList({
     }, [ssrGatherings, selectedMainType, selectedSubType]);
 
     const filteredCSRGatherings = useMemo(() => {
-        if (isSavedPage) {
-            return [];
-        }
-
+        if (isSavedPage) return [];
         return filterGatheringsByType(infiniteGatherings, selectedMainType, selectedSubType);
     }, [infiniteGatherings, selectedMainType, selectedSubType, isSavedPage]);
 
+    
     const allGatherings = useMemo(() => {
-        if (isSavedPage) {
-            return filteredSSRGatherings;
-        }
-
+        if (isSavedPage) return filteredSSRGatherings;
         const uniqueCSRGatherings = getUniqueGatherings(filteredCSRGatherings, filteredSSRGatherings);
         return filteredSSRGatherings.concat(uniqueCSRGatherings);
     }, [filteredSSRGatherings, filteredCSRGatherings, isSavedPage]);
 
-    // 로딩 상태 계산
-    const isLoading = isFilterChanged || (enableInfiniteScroll && !isSavedPage && status === 'pending');
+    // useCallback으로 함수 최적화 + useTransition 적용
+    const handleGatheringClick = useCallback((gatheringId: number) => {
+        startTransition(() => {
+            router.push(`/gatherings/detail/${gatheringId}`);
+        });
+    }, [router]);
+
+    const isLoading = isFilterChanged || (enableInfiniteScroll && !isSavedPage && status === 'pending') || isPending;
     const isEmpty = allGatherings.length === 0 && !isLoading;
 
     return (
@@ -111,106 +229,24 @@ export default function GatheringsList({
         >
             {allGatherings.map((gathering: Gathering, index: number) => {
                 const isLastItem = index === allGatherings.length - 1;
+                const shouldAttachRef = isLastItem && !isFetchingNextPage && enableInfiniteScroll && !isSavedPage;
 
                 return (
-                    <article
-                        role="button"
-                        tabIndex={0}
+                    <GatheringItem
                         key={`${gathering.teamId || 'unknown'}-${gathering.id}-${index}`}
-                        onClick={() => router.push(`/gatherings/detail/${gathering.id}`)}
-                        ref={isLastItem && !isFetchingNextPage && enableInfiniteScroll && !isSavedPage ? lastItemRef : undefined}
-                        className="w-full flex flex-col md:flex-row justify-start border border-gray-200 dark:border-dark-2 dark:bg-dark-2 rounded-2xl bg-white hover:border-main-300 dark:hover:border-main-400 hover:shadow-lg dark:hover:shadow-dark-lg transition-all duration-300 overflow-hidden relative cursor-pointer"
-                        aria-label={`${gathering.name} 모임`}
-                    >
-                        {/* 이미지 영역 */}
-                        <div className="w-full md:w-80 h-48 md:h-40 flex-shrink-0">
-                            <DateReminder registrationEnd={gathering.registrationEnd} />
-                            <ImageWithFallback
-                                src={gathering.image}
-                                fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
-                                alt={`${gathering.name} 모임 썸네일`}
-                                width={320}
-                                height={180}
-                                className="w-full h-full rounded-t-2xl md:rounded-l-2xl md:rounded-t-none object-cover pointer-events-none"
-                            />
-                        </div>
-
-                        <div className="flex-1 flex flex-col justify-between p-4 md:p-6 min-h-0">
-                            <div className="flex-1 w-full">
-                                <div className="flex flex-row md:justify-between gap-3">
-                                    <div className="flex-1 flex flex-row gap-2 items-center">
-                                        <h2 className="text-sm sm:text-lg font-semibold -mt-6 text-gray-900 dark:text-gray-100 transition-colors duration-200">
-                                            {truncateTitle(gathering.name)}
-                                        </h2>
-                                        <div className="hidden md:block w-[2px] h-[16px] -mt-6 bg-gray-900 dark:bg-gray-300"></div>
-                                        <p className="text-sm font-medium -mt-6 text-gray-700 dark:text-gray-300 transition-colors duration-200">
-                                            {gathering.location}
-                                        </p>
-                                    </div>
-                                    <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0">
-                                        <SaveToggleButton gatheringId={gathering.id.toString()} />
-                                    </div>
-                                </div>
-
-                                {gathering.dateTime && (
-                                    <div className="flex flex-wrap gap-2 mb-3 -mt-3">
-                                        <span className={`${BADGE_BASE_STYLES} bg-main-400 text-white dark:bg-main-600 dark:text-gray-100`}>
-                                            {formatDate(gathering.dateTime)}
-                                        </span>
-                                        <span className={`${BADGE_BASE_STYLES} border-2 border-main-400 text-main-400 dark:border-main-400 dark:text-main-400 dark:bg-none`}>
-                                            {formatTime(gathering.dateTime)}
-                                        </span>
-                                    </div>
-                                )}
-                            </div>
-
-                            <div className="flex flex-row items-center justify-between">
-                                <div className="flex items-center gap-2">
-                                    <UserRoundCheck className="size-4 text-main-400 dark:text-main-400" />
-                                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors duration-200">
-                                        {gathering.participantCount}/{gathering.capacity}
-                                    </span>
-                                </div>
-                                <div className="w-full px-2">
-                                    <JoinedCountsProgressBar
-                                        participantCount={gathering.participantCount}
-                                        capacity={gathering.capacity}
-                                    />
-                                </div>
-                            </div>
-                        </div>
-                    </article>
+                        gathering={gathering}
+                        index={index}
+                        isLastItem={isLastItem}
+                        lastItemRef={shouldAttachRef ? lastItemRef : undefined}
+                        onGatheringClick={handleGatheringClick}
+                    />
                 );
             })}
 
-            {/* 무한 스크롤 로딩 */}
-            {enableInfiniteScroll && isFetchingNextPage && (
-                <div className="w-full h-[80px] flex justify-center items-center">
-                    <div className="flex items-center gap-3">
-                        <div className="size-4 border-3 border-main-400 dark:border-main-400 border-t-transparent rounded-full animate-spin"></div>
-                        <span className="text-gray-600 dark:text-gray-400 font-medium transition-colors duration-200">더 많은 모임을 불러오는 중...</span>
-                    </div>
-                </div>
-            )}
-
-            {/* 통합된 로딩 상태 */}
-            {isLoading && (
-                <div className="w-full h-[300px] flex flex-col justify-center items-center text-gray-500 dark:text-gray-400 font-medium text-sm transition-colors duration-200">
-                    <div className="flex items-center gap-3 mb-2">
-                        <div className="size-6 border-3 border-main-400 dark:border-main-400 border-t-transparent rounded-full animate-spin"></div>
-                        <p className="text-lg font-semibold">로딩 중...</p>
-                    </div>
-                    <p>모임을 불러오고 있어요</p>
-                </div>
-            )}
-
-            {/* 모임 없음 */}
-            {isEmpty && (
-                <div className="w-full h-[300px] flex flex-col justify-center items-center text-gray-500 dark:text-gray-400 font-medium text-sm transition-colors duration-200">
-                    <p className="text-lg font-semibold mb-2">아직 모임이 없어요</p>
-                    <p>곧 새로운 모임이 열릴 예정이에요</p>
-                </div>
-            )}
+            {/* 상태별 컴포넌트 */}
+            {enableInfiniteScroll && isFetchingNextPage && <InfiniteScrollLoader />}
+            {isLoading && <LoadingState />}
+            {isEmpty && <EmptyState />}
         </section>
     );
 }

--- a/src/components/reviews/ReviewsList.tsx
+++ b/src/components/reviews/ReviewsList.tsx
@@ -129,9 +129,30 @@ export default function ReviewsList({
         return locationDateFiltered;
     }, [ssrReviews, infiniteReviews, selectedMainType, selectedSubType, filters]);
 
-    // 로딩 상태 계산
-    const isLoading = isFilterChanged || (enableInfiniteScroll && status === 'pending');
-    const isEmpty = allReviews.length === 0 && !isLoading;
+    // 더 명확한 로딩 상태 계산
+    const hasData = allReviews.length > 0;
+    const isApiLoading = enableInfiniteScroll && status === 'pending';
+    const isFilterLoading = isFilterChanged;
+    
+    // 서버에서 데이터를 받았다면 (빈 데이터라도) 로딩 표시하지 않음
+    // 오직 초기 로드 시에만 로딩 표시
+    const shouldShowLoading = isFilterLoading && !hasData;
+    const shouldShowEmpty = !hasData && !shouldShowLoading;
+
+    // 디버깅 로그 (개발 환경에서만)
+    console.log('🔍 ReviewsList Debug:', {
+        ssrReviewsLength: ssrReviews.length,
+        infiniteReviewsLength: infiniteReviews.length,
+        allReviewsLength: allReviews.length,
+        status,
+        isFilterChanged,
+        hasData,
+        isApiLoading,
+        isFilterLoading,
+        shouldShowLoading,
+        shouldShowEmpty,
+        filters
+    });
 
     return (
         <section className="w-full flex flex-col">
@@ -197,7 +218,7 @@ export default function ReviewsList({
                 )}
 
                 {/* 로딩 상태 */}
-                {isLoading && (
+                {shouldShowLoading && (
                     <div className="w-full h-[300px] flex flex-col justify-center items-center text-gray-500 dark:text-gray-400 font-medium text-sm transition-colors duration-200">
                         <div className="flex items-center gap-3 mb-2">
                             <div className="size-6 border-3 border-main-500 border-t-transparent rounded-full animate-spin"></div>
@@ -208,7 +229,7 @@ export default function ReviewsList({
                 )}
 
                 {/* 빈 목록 메시지 */}
-                {isEmpty && (
+                {shouldShowEmpty && (
                     <div className="w-full h-[300px] flex flex-col justify-center items-center text-gray-500 dark:text-gray-400 font-medium text-sm transition-colors duration-200">
                         <p className="text-lg font-semibold mb-2">선택한 조건에 맞는 리뷰가 없어요</p>
                         <p>다른 조건으로 검색해보세요</p>

--- a/src/components/saved/SavedGatheringUI.tsx
+++ b/src/components/saved/SavedGatheringUI.tsx
@@ -2,48 +2,17 @@
 
 import { useState } from 'react';
 import { useToggleSavedGatherings } from '@/hooks/api/saved/useToggleSavedGatherings';
-import { useQuery } from '@tanstack/react-query';
-import { allSavedQueries } from '@/queries/saved.query';
-import { internalClient } from '@/lib/api/clientFetchers';
-import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
-import { Gathering } from '@/types/gatherings';
+import { useSavedGatherings } from '@/hooks/api/saved/useSavedGatherings';
 import GatheringsList from '@/components/gatherings/GatheringsList';
 import GatheringFilters from '@/components/shared/GatheringsFilters';
 import PagesHeader from '@/components/shared/PagesHeader';
-
-// 매직넘버 상수
-const API_LIMIT = 1000; // 모임 조회 제한
 
 export default function SavedGatheringsUI() {
     const [selectedMainType, setSelectedMainType] = useState('DALLAEMFIT');
     const [selectedSubType, setSelectedSubType] = useState('ALL');
 
     const { savedIds } = useToggleSavedGatherings();
-
-    const { data: savedGatherings = [] } = useQuery({
-        queryKey: allSavedQueries.idsByFilter(savedIds),
-        queryFn: async () => {
-            if (savedIds.length === 0) return [];
-
-            const response = await internalClient.get(INTERNAL_PATHS.GATHERINGS, {
-                params: { limit: API_LIMIT }
-            });
-
-            const gatherings = response.data;
-
-            const gatheringsMap = new Map(
-                gatherings.map((gathering: Gathering) => [gathering.id.toString(), gathering])
-            );
-
-            return savedIds
-                .map(id => gatheringsMap.get(id))
-                .filter((gathering): gathering is Gathering => gathering !== undefined);
-        },
-        enabled: savedIds.length > 0,
-        retry: 2,
-        refetchOnWindowFocus: false,
-        placeholderData: (previousData) => previousData,
-    });
+    const { data: savedGatherings = [] } = useSavedGatherings(savedIds);
 
     const handleTypeChange = (mainType: string, subType: string) => {
         setSelectedMainType(mainType);

--- a/src/hooks/api/saved/useSavedGatherings.ts
+++ b/src/hooks/api/saved/useSavedGatherings.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { allSavedQueries } from '@/queries/saved.query';
+import { internalClient } from '@/lib/api/clientFetchers';
+import { INTERNAL_PATHS } from '@/lib/api/apiPaths';
+import { Gathering } from '@/types/gatherings';
+
+// 매직넘버 상수
+const API_LIMIT = 1000; // 모임 조회 제한
+
+export const useSavedGatherings = (savedIds: string[]) => {
+    return useQuery({
+        queryKey: allSavedQueries.idsByFilter(savedIds),
+        queryFn: async () => {
+            if (savedIds.length === 0) return [];
+
+            const response = await internalClient.get(INTERNAL_PATHS.GATHERINGS, {
+                params: { limit: API_LIMIT }
+            });
+
+            const gatherings = response.data;
+
+            const gatheringsMap = new Map(
+                gatherings.map((gathering: Gathering) => [gathering.id.toString(), gathering])
+            );
+
+            return savedIds
+                .map(id => gatheringsMap.get(id))
+                .filter((gathering): gathering is Gathering => gathering !== undefined);
+        },
+        enabled: savedIds.length > 0,
+        retry: 2,
+        refetchOnWindowFocus: false,
+        placeholderData: (previousData) => previousData,
+    });
+};

--- a/src/types/reviews.ts
+++ b/src/types/reviews.ts
@@ -39,7 +39,6 @@ export interface ReviewItem {
  * @type location: 모임 장소
  * @type image: 모임 이미지
  * @type participantCount: 참여인원 수 (추가)
- * @type capacity: 최대 정원 (추가)
  */
 export interface GatheringInfo {
     teamId: number;
@@ -50,7 +49,6 @@ export interface GatheringInfo {
     location: string;
     image: string;
     participantCount: number;
-    capacity: number;
 }
 
 /**


### PR DESCRIPTION
## 📌[refactor] 찜목록 useQuery 로직 분리
### SavedGatheringsUI.tsx, useSavedGatherings.ts
- 코드 가독성 향상

## 📌[fix] 리뷰 페이지 로딩 상태 개선
### reviewList.tsx
- 서버에서 빈 데이터를 받았을 때 무한 로딩 이슈 해결
- 필터 변경 시에만 로딩 표시하도록 조건 수정
- 백그라운드 API 호출과 UI 상태를 분리하여 사용자 경험 개선