### PR TITLE
[refactor] 모임 찾기, 상세 / 랜딩 페이지 이미지 최적화

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -169,6 +169,7 @@ export default async function MainPage() {
               alt="메인 히어로 이미지"
               width={1000}
               height={1000}
+              sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
               priority
               className="w-2/3 mx-auto pointer-events-none" />
           </div>

--- a/src/components/gatherings/GatheringsList.tsx
+++ b/src/components/gatherings/GatheringsList.tsx
@@ -84,12 +84,12 @@ const InfiniteScrollLoader = memo(() => (
 ));
 
 // 개별 모임 아이템 컴포넌트 memo로 최적화
-const GatheringItem = memo(({ 
-    gathering, 
-    index, 
-    isLastItem, 
+const GatheringItem = memo(({
+    gathering,
+    index,
+    isLastItem,
     lastItemRef,
-    onGatheringClick 
+    onGatheringClick
 }: {
     gathering: Gathering;
     index: number;
@@ -113,8 +113,10 @@ const GatheringItem = memo(({
                 src={gathering.image}
                 fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
                 alt={`${gathering.name} 모임 썸네일`}
-                width={320}
-                height={180}
+                width={1000}
+                height={1000}
+                sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                priority
                 className="w-full h-full rounded-t-2xl md:rounded-l-2xl md:rounded-t-none object-cover pointer-events-none"
             />
         </div>
@@ -205,7 +207,7 @@ export default function GatheringsList({
         return filterGatheringsByType(infiniteGatherings, selectedMainType, selectedSubType);
     }, [infiniteGatherings, selectedMainType, selectedSubType, isSavedPage]);
 
-    
+
     const allGatherings = useMemo(() => {
         if (isSavedPage) return filteredSSRGatherings;
         const uniqueCSRGatherings = getUniqueGatherings(filteredCSRGatherings, filteredSSRGatherings);

--- a/src/components/gatherings/detail/Thumbnail.tsx
+++ b/src/components/gatherings/detail/Thumbnail.tsx
@@ -18,6 +18,8 @@ export default function Thumbnail({ detail, id }: { detail: Gathering, id: strin
                 alt='모임 썸네일'
                 width={1000}
                 height={1000}
+                sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                priority
                 className='w-full h-full object-cover rounded-lg'
             />
             <div className='absolute sm:hidden top-3 right-3'>


### PR DESCRIPTION
## 📌 모임 찾기, 상세 / 랜딩 페이지 이미지 최적화
- 모임 찾기: `alt={`${gathering.name} 모임 썸네일`}`
- 모임 상세: `alt='모임 썸네일'`
- 랜딩 페이지: `alt="메인 히어로 이미지"`
- sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
- priority


