### PR TITLE
[refactor] 마이페이지 이미지 최적화, 랜딩 페이지 핫한 모임 스타일 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -102,13 +102,14 @@ const GatheringCard = ({
         className="w-full h-32 object-cover rounded-xl pointer-events-none" />
       <div className="space-y-2">
         <h3 className="font-semibold group-hover:text-main-500 dark:text-white dark:group-hover:text-main-500 transition-all">{title}</h3>
-        <p className="text-sm text-gray-500 dark:text-white">{schedule}</p>
-        <div className="flex items-center gap-2">
-          <span className={`px-2 py-1 rounded-full bg-main-400 text-xs text-white`}>
-            {category}
-          </span>
+        <div className='flex items-center gap-1'>
+          <span className="text-sm text-gray-500 dark:text-white">{schedule}</span>
+          <span className='text-gray-500 dark:text-white'>|</span>
           <span className="text-sm text-gray-500 dark:text-white"><span className='font-semibold text-main-500'>{participants}</span>명 참여</span>
         </div>
+        <span className={`px-2 py-1 rounded-full bg-main-400 text-xs text-white text-center`}>
+          {category}
+        </span>
       </div>
     </div>
   </Link>

--- a/src/components/mypage/CreatableReview.tsx
+++ b/src/components/mypage/CreatableReview.tsx
@@ -19,6 +19,8 @@ export default function CreatableReview({ gathering, myReviewsTab, userId, onOpe
                     alt="모임 썸네일"
                     width={1000}
                     height={1000}
+                    sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                    priority
                     className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
                 />
             </div>

--- a/src/components/mypage/CreateReviewDialog.tsx
+++ b/src/components/mypage/CreateReviewDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { useCreateReview } from '@/hooks/api/mypage/useCreateReview';
 import { useForm } from 'react-hook-form';
@@ -10,7 +10,6 @@ import { excapeForXSS } from '@/utils/shared/excapeForXSS';
 import { Heart } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Button from '@/components/shared/Button';
-import { useEffect } from 'react';
 
 const ConfirmDialog = dynamic(() => import('@/components/shared/ConfirmDialog'), { ssr: false });
 
@@ -66,8 +65,8 @@ export default function CreateReviewDialog({
     createReview({ gatheringId: reviewFormData.gatheringId, score: data.score, comment: excapeForXSS(data.comment) });
   };
 
+  // ESC 키 눌렀을 때 다이얼로그 닫기
   useEffect(() => {
-    // ESC 키 눌렀을 때 다이얼로그 닫기
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };

--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -44,6 +44,8 @@ export default function CreatedGatherings() {
                 alt='모임 썸네일'
                 width={1000}
                 height={1000}
+                sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                priority
                 className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
               />
             </div>

--- a/src/components/mypage/CreatedReview.tsx
+++ b/src/components/mypage/CreatedReview.tsx
@@ -15,6 +15,8 @@ export default function CreatedReview({ review }: { review: ReviewItem }) {
                     alt="모임 썸네일"
                     width={1000}
                     height={1000}
+                    sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                    priority
                     className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
                 />
             </div>

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -93,6 +93,8 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
               alt='모임 썸네일'
               width={1000}
               height={1000}
+              sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+              priority
               className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
             />
           </figure>

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -13,6 +13,7 @@ const ProfileEditDialog = dynamic(() => import('@/components/shared/ProfileEditD
 /** 마이페이지 프로필 카드 */
 export default function ProfileCard() {
   const { userName, userCompanyName, userEmail, userImage, userId } = useContext(AuthContext)
+
   const [isProfileEditDialogOpen, setIsProfileEditDialogOpen] = useState(false);
 
   return (


### PR DESCRIPTION
## 📌 마이페이지 이미지 최적화
• 참여중인 모임, 작성 가능한 리뷰, 작성한 리뷰, 내가 만든 모임 컴포넌트의 모임 썸네일
• sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
• priority

## 📌 랜딩 페이지 핫한 모임 스타일 수정
• 마감 기한과 참여자 수를 같은 row에 배치하고, 뱃지를 가장 아래에 배치