### PR TITLE
[refactor, feature] 마이페이지 motion(m) 애니메이션 구현, 모임 상세 썸네일 해상도 수정…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -204,6 +204,10 @@ html {
   .dialog-background {
     @apply fixed inset-0 z-50 px-4 sm:px-0 flex flex-col items-center justify-center gap-2 bg-black/40 dark:text-white;
   }
+
+  .transition-gathering-item {
+    @apply transition-all duration-250 ease-in-out;
+  }
 }
 
 @layer base {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,7 +70,7 @@ async function getFourMostPopularGatherings(): Promise<Gathering[]> {
 
 /** 피처 카드 */
 const FeatureCard = ({ icon, title, description, gradient }: FeatureCardProps) => (
-  <div className="bg-white p-8 rounded-3xl shadow-sm hover:shadow-lg transition-all group dark:bg-dark-2 dark:text-white">
+  <div className="bg-white p-8 rounded-3xl shadow-sm hover:shadow-lg border-1 transition-all group dark:bg-dark-2 dark:text-white">
     <div className="space-y-6">
       <div className={`size-16 ${gradient} rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform`}>
         <span className="text-2xl text-white">{icon}</span>
@@ -97,7 +97,8 @@ const GatheringCard = ({
       className="space-y-4 group h-full p-6 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-300 bg-white dark:bg-dark-2 hover:shadow-md hover:border-main-300 dark:hover:border-main-400 transition-all"
       initial={{ opacity: 0, y: -20 }}
       whileInView={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8, ease: "easeOut" }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.8, ease: "linear" }}
     >
       {/* 모임 썸네일 위치 */}
       <ImageWithFallback
@@ -131,55 +132,61 @@ export default async function MainPage() {
   const fourMostPopularGatherings = await getFourMostPopularGatherings();
 
   return (
-    // 색상 경계를 없애기 위해 
-    <main className="bg-transparent contents-container">
-      {/* Hero Section */}
+    <div className="bg-transparent contents-container">
+      {/* Header */}
       <header
         id="hero"
-        className="flex-1 flex flex-col lg:flex-row items-center gap-12 px-6 py-12">
-        <div className="flex-1 space-y-8">
+        className="flex-1 flex flex-col lg:flex-row items-center gap-6 py-12">
+        {/* 텍스트 및 프루프 */}
+        <section className="flex-1 space-y-8">
           <div className="space-y-4">
-            <h1 className="text-2xl sm:text-5xl lg:text-6xl font-bold leading-tight">
-              <span className="dark:text-white">가볍게 시작하는</span><br />
-              특별한<span className="bg-gradient-to-r from-[#8B5CF6] to-[#F472B6] bg-clip-text text-transparent"> 만남</span><br />
-            </h1>
+            <div className='flex items-center justify-between'>
+              <h1 className="text-3xl sm:text-5xl lg:text-6xl font-bold leading-tight">
+                <span className="dark:text-white">가볍게 시작하는</span><br />
+                특별한<span className="bg-gradient-to-r from-main-500 to-main-pink bg-clip-text text-transparent"> 만남</span><br />
+              </h1>
+              <Link href="/gatherings" className='inline-block sm:hidden'>
+                <div className="padding-button hover-button bg-button rounded-lg text-button-text text-sm sm:text-base font-semibold hover:bg-main-600 shadow-lg hover:shadow-xl">
+                  지금 시작하기
+                </div>
+              </Link>
+            </div>
             <p className="text-sm sm:text-xl text-gray-500 dark:text-white leading-relaxed max-w-md whitespace-nowrap">
-              서울의 2030이라면 <strong className="text-[#8B5CF6]">Meet Meet</strong>에서 모임을 만들고<br />
+              서울의 2030이라면 <strong className="text-main-500">Meet Meet</strong>에서 모임을 만들고<br />
               새로운 친구를 만들어보세요!
             </p>
           </div>
 
-          <Link href="/gatherings" className='inline-block'>
+          <Link href="/gatherings" className='hidden sm:inline-block'>
             <div className="padding-button hover-button bg-button rounded-lg text-button-text text-sm sm:text-base font-semibold hover:bg-main-600 shadow-lg hover:shadow-xl">
               지금 시작하기
             </div>
           </Link>
 
-          {/* Social Proof */}
-          <div className="flex items-center gap-6 pt-4">
+          <div className="flex items-center gap-4 pt-4">
             <div className="flex -space-x-2">
-              <div className={`${SOCIAL_PROOF_STYLE} bg-[#F6D55C]`}>
+              <div className={`${SOCIAL_PROOF_STYLE} bg-main-apricot`}>
                 <span className="text-sm font-semibold">😊</span>
               </div>
-              <div className={`${SOCIAL_PROOF_STYLE} bg-[#6EE7B7]`}>
+              <div className={`${SOCIAL_PROOF_STYLE} bg-main-jade`}>
                 <span className="text-sm font-semibold">🎨</span>
               </div>
-              <div className={`${SOCIAL_PROOF_STYLE} bg-[#F472B6]`}>
+              <div className={`${SOCIAL_PROOF_STYLE} bg-main-pink`}>
                 <span className="text-sm font-semibold">🏃</span>
               </div>
-              <div className={`${SOCIAL_PROOF_STYLE} bg-gray-200`}>
-                <span className="text-xs font-bold text-gray-500">+99</span>
+              <div className={`${SOCIAL_PROOF_STYLE} bg-slate-200`}>
+                <span className="text-xs font-bold text-gray-500">+88</span>
               </div>
             </div>
             <div className="text-sm text-gray-500 dark:text-white">
-              <strong className="text-[#8B5CF6]">12,000+</strong> 명이 이미 만남을 시작했어요
+              <strong className="text-main-500">3,300+</strong> 명이 이미 만남을 시작했어요
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="flex-1 relative">
-          {/* 메인 히어로 이미지 */}
-          <div className="w-full max-w-md mx-auto h-96 bg-gradient-to-br from-main-100 to-pink-200 rounded-3xl shadow-2xl flex items-center justify-center">
+        {/* 히어로  */}
+        <section className="flex-1 relative">
+          <div className="w-full mx-auto h-96 bg-gradient-to-br from-main-100 to-pink-200 rounded-3xl shadow-2xl flex items-center justify-center">
             <Image src="https://res.cloudinary.com/dbvzbdffi/image/upload/v1750301404/logo_hero_zeiiec.avif"
               alt="메인 히어로 이미지"
               width={317}
@@ -188,111 +195,113 @@ export default async function MainPage() {
               fetchPriority='high'
               className="w-2/3 mx-auto pointer-events-none" />
           </div>
-          {/* Floating Elements */}
-          <div className="absolute top-4 right-4 w-16 h-16 bg-[#F6D55C] rounded-full flex items-center justify-center shadow-lg animate-bounce">
+          <div className="absolute top-4 right-4 w-16 h-16 bg-main-apricot rounded-full flex items-center justify-center shadow-lg animate-bounce">
             <span className="text-2xl">💛</span>
           </div>
-          <div className="absolute bottom-8 left-4 w-12 h-12 bg-[#6EE7B7] rounded-full flex items-center justify-center shadow-lg animate-bounce">
+          <div className="absolute bottom-8 left-4 w-12 h-12 bg-main-jade rounded-full flex items-center justify-center shadow-lg animate-bounce">
             <span className="text-xl">🌟</span>
           </div>
-        </div>
+        </section>
       </header>
 
-      {/* 피쳐 */}
-      <section
-        id="features"
-        className="px-6 py-16 space-y-16"
-      >
-        <div className="text-center space-y-4">
-          <h2 className="text-2xl sm:text-4xl font-bold dark:text-white">
-            왜 <span className="bg-gradient-to-r from-[#8B5CF6] to-[#F472B6] bg-clip-text text-transparent">Meet Meet</span>일까요?
-          </h2>
-          <p className="text-sm sm:text-lg text-gray-500 dark:text-white max-w-2xl mx-auto">
-            내가 찾는 모임을 쉽게 조건에 따라 찾을 수 있어요
-          </p>
-        </div>
-
-        <m.article className="grid md:grid-cols-3 gap-8"
-          initial={{ opacity: 0, y: 20, }}
-          whileInView={{ opacity: 1, y: 0, }}
-          transition={{ duration: 0.8, delay: 0.2 }}
-          viewport={{ once: true, amount: 1, }}
+      {/* Main */}
+      <main>
+        {/* 피쳐 */}
+        <section
+          id="features"
+          className="py-16 space-y-10"
         >
-          <FeatureCard
-            icon="👥"
-            title="북적북적/도란도란"
-            description="모임의 성격을 기준으로 구분했어요"
-            gradient="bg-gradient-to-r from-main-jade to-main-apricot"
-          />
-          <FeatureCard
-            icon="🎯"
-            title="찜해두기"
-            description="찜해두기 기능으로 원하는 모임을 쉽게 찾을 수 있어요"
-            gradient="bg-gradient-to-r from-main-apricot to-main-pink"
-          />
-          <FeatureCard
-            icon="💬"
-            title="리뷰 시스템"
-            description="실제 이용자들이 남긴 리뷰로 모임의 소감을 알 수 있어요"
-            gradient="bg-gradient-to-r from-main-pink to-main-500"
-          />
-        </m.article>
-      </section>
-
-      {/* 지금 핫한 모임 */}
-      <section
-        id="community"
-        className="px-6 py-16 bg-gradient-to-r from-purple-50 to-pink-50 dark:from-dark-2 dark:to-dark-2 rounded-3xl"
-      >
-        <div className="space-y-12">
-          <div
-            className="text-center space-y-4"
-          >
-            <h2 className="text-4xl font-bold dark:text-white">
-              지금 <span className="bg-gradient-to-r from-main-apricot via-main-pink to-main-500 bg-clip-text text-transparent">HOT한</span> 모임들
+          <div className="text-center space-y-4">
+            <h2 className="text-2xl sm:text-4xl font-bold dark:text-white">
+              왜 <span className="bg-gradient-to-r from-main-500 to-main-pink bg-clip-text text-transparent">Meet Meet</span>일까요?
             </h2>
-            <m.p
-              className="text-lg text-gray-500 dark:text-white"
-              initial={{ x: -30, opacity: 0 }}
-              whileInView={{ x: 0, opacity: 1 }}
-              transition={{ duration: 0.8, delay: 0.2 }}
+            <p className="text-sm sm:text-lg text-gray-500 dark:text-white max-w-2xl mx-auto">
+              내가 찾는 모임을 쉽게 조건에 따라 찾을 수 있어요
+            </p>
+          </div>
+
+          <m.article className="grid md:grid-cols-3 gap-8"
+            initial={{ opacity: 0, y: 20, }}
+            whileInView={{ opacity: 1, y: 0, }}
+            viewport={{ once: true, amount: 0.4, }}
+            transition={{ duration: 0.8, delay: 0.2 }}
+          >
+            <FeatureCard
+              icon="👥"
+              title="북적북적/도란도란"
+              description="모임의 성격을 기준으로 구분했어요"
+              gradient="bg-gradient-to-r from-main-jade to-main-apricot"
+            />
+            <FeatureCard
+              icon="🎯"
+              title="찜해두기"
+              description="찜해두기 기능으로 원하는 모임을 쉽게 찾을 수 있어요"
+              gradient="bg-gradient-to-r from-main-apricot to-main-pink"
+            />
+            <FeatureCard
+              icon="💬"
+              title="리뷰 시스템"
+              description="실제 이용자들이 남긴 리뷰로 모임의 소감을 알 수 있어요"
+              gradient="bg-gradient-to-r from-main-pink to-main-500"
+            />
+          </m.article>
+        </section>
+
+        {/* 지금 핫한 모임 */}
+        <section
+          id="community"
+          className="px-6 py-16 bg-gradient-to-r from-purple-50 to-pink-50 dark:from-dark-2 dark:to-dark-2 rounded-3xl"
+        >
+          <div className="space-y-12">
+            <div
+              className="text-center space-y-4"
             >
-              다양한 사람들이 만나고 있는 인기 모임에 참여해보시는 건 어떤가요?
-            </m.p>
-          </div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {fourMostPopularGatherings.map((gathering) => {
-              return (
-                <GatheringCard
-                  key={`${gathering.id} - ${gathering.dateTime}`}
-                  title={gathering.name}
-                  link={`/gatherings/detail/${gathering.id}`}
-                  schedule={getTimeRemaining(gathering.registrationEnd)}
-                  category={GATHERING_TYPES.find(type => type.id === gathering.type)?.title as 'MINDFULNESS' | 'WORKATION' | 'OFFICE_STRETCHING'}
-                  participants={gathering.participantCount}
-                  image={gathering.image}
-                />
-              )
-            })}
-          </div>
-
-          <div className="text-center">
-            <Link href="/gatherings" className='inline-block'>
-              <m.div
-                className="px-8 py-3 rounded-xl shadow-sm hover:shadow-md border border-main-300 bg-button-text dark:bg-dark-2 hover:bg-button dark:hover:bg-button text-button hover:text-button-text font-semibold transition-all"
-                initial={{ opacity: 0 }}
-                whileInView={{ opacity: 1 }}
+              <h2 className="text-4xl font-bold dark:text-white">
+                지금 <span className="bg-gradient-to-r from-main-apricot via-main-pink to-main-500 bg-clip-text text-transparent">HOT한</span> 모임들
+              </h2>
+              <m.p
+                className="text-lg text-gray-500 dark:text-white"
+                initial={{ x: -30, opacity: 0 }}
+                whileInView={{ x: 0, opacity: 1 }}
                 transition={{ duration: 0.8, delay: 0.2 }}
-                viewport={{ once: true, amount: 0.5, }}
+                viewport={{ once: true }}
               >
-                더 많은 모임 보기
-              </m.div>
-            </Link>
-          </div>
-        </div>
-      </section>
+                다양한 사람들이 만나고 있는 인기 모임에 참여해보시는 건 어떤가요?
+              </m.p>
+            </div>
 
+            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+              {fourMostPopularGatherings.map((gathering) => {
+                return (
+                  <GatheringCard
+                    key={`${gathering.id} - ${gathering.dateTime}`}
+                    title={gathering.name}
+                    link={`/gatherings/detail/${gathering.id}`}
+                    schedule={getTimeRemaining(gathering.registrationEnd)}
+                    category={GATHERING_TYPES.find(type => type.id === gathering.type)?.title as 'MINDFULNESS' | 'WORKATION' | 'OFFICE_STRETCHING'}
+                    participants={gathering.participantCount}
+                    image={gathering.image}
+                  />
+                )
+              })}
+            </div>
+
+            <div className="text-center">
+              <Link href="/gatherings" className='inline-block'>
+                <m.div
+                  className="px-8 py-3 rounded-xl shadow-sm hover:shadow-md border border-main-300 bg-button-text dark:bg-dark-2 hover:bg-button dark:hover:bg-button text-button hover:text-button-text font-semibold transition-all"
+                  initial={{ opacity: 0 }}
+                  whileInView={{ opacity: 1 }}
+                  transition={{ duration: 0.8, delay: 0.2 }}
+                  viewport={{ once: true, amount: 0.5, }}
+                >
+                  더 많은 모임 보기
+                </m.div>
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
 
       {/* Footer */}
       <footer className="px-6 py-12 bg-gray-800 rounded-3xl text-white">
@@ -360,7 +369,7 @@ export default async function MainPage() {
           </div>
         </div>
       </footer>
-    </main>
+    </div>
   );
 };
 

--- a/src/components/gatherings/SelectionService.tsx
+++ b/src/components/gatherings/SelectionService.tsx
@@ -18,7 +18,7 @@ const ServiceItem = ({ id, title, subtitle, isSelected, onSelect }: { id: string
             tabIndex={0}
         >
             <div className="flex flex-col justify-start gap-4">
-                <div className="flex flex-row items-center gap-2">
+                <div className="flex flex-col sm:flex-row items-center gap-2">
                     <input
                         type="radio"
                         name="service"
@@ -28,10 +28,10 @@ const ServiceItem = ({ id, title, subtitle, isSelected, onSelect }: { id: string
                         className="accent-main-500 rounded-lg w-[18px] h-[18px]"
                         aria-label={`${title} ${subtitle ? subtitle : ''} 선택`}
                     />
-                    <h3 className='font-semibold text-sm md:text-base'>{title}</h3>
+                    <h3 className='font-semibold text-xs sm:text-sm md:text-base'>{title}</h3>
                 </div>
                 {subtitle && (
-                    <span className='text-xs font-medium flex text-gray-600 dark:text-gray-300'>
+                    <span className='text-2xs sm:text-xs font-medium flex items-center sm:items-start text-gray-600 dark:text-gray-300'>
                         {subtitle}
                     </span>
                 )}

--- a/src/components/gatherings/detail/Information.tsx
+++ b/src/components/gatherings/detail/Information.tsx
@@ -15,7 +15,7 @@ interface InformationProps {
     participants: Participant[],
 }
 
-const LOCATION_POSTER_STYLE = 'text-sm md:text-base text-gray-500 dark:text-gray-400';
+const LOCATION_POSTER_STYLE = 'text-sm text-gray-500 dark:text-gray-400';
 const BOTTOM_SECTION_TEXT_STYLE = 'text-xs md:text-sm';
 
 /** 모임 상세 페이지 상단 우측 정보 */
@@ -29,11 +29,7 @@ export default function Information({ detail, id, participants }: InformationPro
                     {/* 제목, 주소 */}
                     <div className="flex flex-col min-w-0">
                         <h2 className="text-base md:text-xl font-bold max-w-full" title={detail?.name}>
-                            {detail?.name
-                                ? detail.name.length > 20
-                                    ? detail.name.slice(0, 20) + '...'
-                                    : detail.name
-                                : ''}
+                            {shortenName(detail?.name, 20)}
                         </h2>
                         <div className='flex items-center gap-1'>
                             <span className={LOCATION_POSTER_STYLE}>{detail?.location || '-'}</span>

--- a/src/components/gatherings/detail/Thumbnail.tsx
+++ b/src/components/gatherings/detail/Thumbnail.tsx
@@ -16,9 +16,8 @@ export default function Thumbnail({ detail, id }: { detail: Gathering, id: strin
                 src={detail?.image}
                 fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
                 alt='모임 썸네일'
-                width={1000}
-                height={1000}
-                sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                width={454}
+                height={238}
                 priority
                 className='w-full h-full object-cover rounded-lg'
             />

--- a/src/components/mypage/CreatableReview.tsx
+++ b/src/components/mypage/CreatableReview.tsx
@@ -1,27 +1,38 @@
 import { useGatheringsStore } from '@/store/gatheringsStore';
 import { Gathering } from '@/types/gatherings';
-import { THUMBNAIL_CLASSNAME, THUMBNAIL_WIDTH } from '@/utils/mypage/constants/thumbnailConstants';
+import { THUMBNAIL_CLASSNAME, THUMBNAIL_SIZE } from '@/utils/mypage/constants/thumbnailConstants';
+import * as m from "motion/react-m";
 import ImageWithFallback from '@/components/shared/ImageWithFallback';
 import GatheringInformation from '@/components/mypage/GatheringInformation';
 import Button from '@/components/shared/Button';
 
+interface CreatableReviewProps {
+    gathering: Gathering
+    myReviewsTab: number, userId: number,
+    onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void;
+}
+
 /** 나의 리뷰 - 작성 가능한 리뷰 */
-export default function CreatableReview({ gathering, myReviewsTab, userId, onOpenReviewDialog }: { gathering: Gathering, myReviewsTab: number, userId: number, onOpenReviewDialog: (gathering: { userId: number, gatheringId: number }) => void }) {
+export default function CreatableReview({ gathering, myReviewsTab, userId, onOpenReviewDialog }: CreatableReviewProps) {
     const setCurrentGatheringId = useGatheringsStore(state => state.setCurrentGatheringId);
 
     return (
-        <article className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item dark:bg-dark-2">
+        <m.article
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
+            viewport={{ amount: 0.5, once: true }}
+            className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item dark:bg-dark-2">
             {/* 이미지 */}
-            <div className="flex-shrink-0">
+            <div className="flex-shrink-0 h-[10rem]">
                 <ImageWithFallback
                     src={gathering.image}
                     fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
                     alt="모임 썸네일"
-                    width={1000}
-                    height={1000}
-                    sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                    width={298}
+                    height={170}
                     priority
-                    className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
+                    className={`${THUMBNAIL_SIZE} ${THUMBNAIL_CLASSNAME}`}
                 />
             </div>
             {/* 정보 */}
@@ -38,7 +49,7 @@ export default function CreatableReview({ gathering, myReviewsTab, userId, onOpe
                     />
                 )}
             </GatheringInformation>
-        </article>
+        </m.article>
     );
 }
 

--- a/src/components/mypage/CreatedGatherings.tsx
+++ b/src/components/mypage/CreatedGatherings.tsx
@@ -4,7 +4,8 @@ import { useFetchCreatedGatherings } from '@/hooks/api/mypage/useFetchCreatedGat
 import { useContext } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { getTimeRemaining } from '@/utils/shared/date';
-import { THUMBNAIL_CLASSNAME, THUMBNAIL_WIDTH } from '@/utils/mypage/constants/thumbnailConstants';
+import { THUMBNAIL_CLASSNAME, THUMBNAIL_SIZE } from '@/utils/mypage/constants/thumbnailConstants';
+import * as m from "motion/react-m";
 import dynamic from 'next/dynamic';
 import ImageWithFallback from '@/components/shared/ImageWithFallback';
 import GatheringInformation from '@/components/mypage/GatheringInformation';
@@ -31,22 +32,25 @@ export default function CreatedGatherings() {
     <section className='flex w-full flex-col gap-2'>
       {!isLoading && !error && gatherings.map(gathering => {
         return (
-          <article
+          <m.article
             key={gathering.id}
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
+            viewport={{ amount: 0.5, once: true }}
             className="relative min-h-[100px] w-full p-4 rounded-xl border-1 hover:border-main-200 dark:bg-dark-2 flex flex-col sm:flex-row gap-4 hover:shadow-md transition-gathering-item"
           >
             {/* 좌측 이미지 */}
-            <div className='relative'>
+            <div className='relative h-[10rem]'>
               <DateReminder registrationEnd={gathering?.registrationEnd} />
               <ImageWithFallback
                 src={gathering?.image}
                 fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
                 alt='모임 썸네일'
-                width={1000}
-                height={1000}
-                sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                width={298}
+                height={170}
                 priority
-                className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
+                className={`${THUMBNAIL_SIZE} ${THUMBNAIL_CLASSNAME}`}
               />
             </div>
 
@@ -54,7 +58,7 @@ export default function CreatedGatherings() {
             <div className='flex flex-col justify-between'>
               <GatheringInformation data={gathering} />
             </div>
-          </article>
+          </m.article>
         );
       })}
     </section>

--- a/src/components/mypage/CreatedReview.tsx
+++ b/src/components/mypage/CreatedReview.tsx
@@ -1,23 +1,32 @@
 import { ReviewItem } from '@/types/reviews';
 import { formatDate, formatTime } from '@/utils/shared/date';
-import { THUMBNAIL_CLASSNAME, THUMBNAIL_WIDTH } from '@/utils/mypage/constants/thumbnailConstants';
+import { THUMBNAIL_CLASSNAME, THUMBNAIL_SIZE } from '@/utils/mypage/constants/thumbnailConstants';
 import { Heart } from 'lucide-react';
+import * as m from "motion/react-m";
 import ImageWithFallback from '@/components/shared/ImageWithFallback';
 
+interface CreatedReviewProps {
+    review: ReviewItem,
+}
+
 /** 나의 리뷰 - 작성한 리뷰 */
-export default function CreatedReview({ review }: { review: ReviewItem }) {
+export default function CreatedReview({ review }: CreatedReviewProps) {
     return (
-        <article className='flex flex-col sm:flex-row gap-4'>
-            <div className="flex-shrink-0">
+        <m.article
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
+            viewport={{ amount: 0.5, once: true }}
+            className={`relative w-full p-4 rounded-xl border hover:border-main-200 hover:shadow-md flex flex-col sm:flex-row gap-4 transition-gathering-item`}>
+            <div className="flex-shrink-0 h-[10rem]">
                 <ImageWithFallback
                     src={review.Gathering.image!}
                     fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
                     alt="모임 썸네일"
-                    width={1000}
-                    height={1000}
-                    sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+                    width={298}
+                    height={170}
                     priority
-                    className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
+                    className={`${THUMBNAIL_SIZE} ${THUMBNAIL_CLASSNAME}`}
                 />
             </div>
             <div className="flex flex-col gap-1">
@@ -37,7 +46,7 @@ export default function CreatedReview({ review }: { review: ReviewItem }) {
                     </span>
                 </div>
             </div>
-        </article>
+        </m.article>
     );
 }
 

--- a/src/components/mypage/JoinedGatherings.tsx
+++ b/src/components/mypage/JoinedGatherings.tsx
@@ -5,8 +5,9 @@ import { useLeaveGathering } from '@/hooks/api/gatherings/detail/useLeaveGatheri
 import { useContext, useState, useEffect } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { getTimeRemaining, toKoreanTime } from '@/utils/shared/date';
-import { THUMBNAIL_CLASSNAME, THUMBNAIL_WIDTH } from '@/utils/mypage/constants/thumbnailConstants';
+import { THUMBNAIL_CLASSNAME, THUMBNAIL_SIZE } from '@/utils/mypage/constants/thumbnailConstants';
 import { CheckCircle } from "lucide-react"
+import * as m from "motion/react-m";
 import dynamic from 'next/dynamic';
 import Button from '@/components/shared/Button';
 import GatheringInformation from '@/components/mypage/GatheringInformation';
@@ -73,8 +74,12 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
   return (
     <section className='flex flex-col gap-2'>
       {sortedGatherings.map(data => (
-        <article
+        <m.article
           key={data.id}
+          initial={{ opacity: 0 }}
+          whileInView={{ opacity: 1 }}
+          transition={{ duration: 0.8, delay: 0.2, ease: "easeOut" }}
+          viewport={{ amount: 0.5, once: true }}
           className="relative min-h-[100px] w-full p-4 rounded-xl flex flex-col sm:flex-row gap-4 border-1 hover:border-main-200 hover:shadow-md transition-gathering-item dark:bg-dark-2 dark:text-white"
         >
           {/* 마감 완료 및 5명 미만 */}
@@ -85,17 +90,16 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
           />
 
           {/* 좌측 */}
-          <figure className='relative'>
+          <figure className='relative h-[10rem]'>
             <DateReminder registrationEnd={data?.registrationEnd} />
             <ImageWithFallback
               src={data?.image}
               fallbackSrc='https://res.cloudinary.com/dbvzbdffi/image/upload/v1750048546/error_fallback_icbngz.avif'
               alt='모임 썸네일'
-              width={1000}
-              height={1000}
-              sizes="(max-width: 401px) 300px, (max-width: 801px) 500px, 1000px"
+              width={298}
+              height={170}
               priority
-              className={`${THUMBNAIL_WIDTH} ${THUMBNAIL_CLASSNAME}`}
+              className={`${THUMBNAIL_SIZE} ${THUMBNAIL_CLASSNAME}`}
             />
           </figure>
 
@@ -162,7 +166,7 @@ export default function JoinedGatherings({ setSelectedTab, setMyReviewsTab, onOp
               />
             </div>
           </article>
-        </article>
+        </m.article>
       ))}
 
       <ConfirmDialog

--- a/src/components/mypage/MyReviews.tsx
+++ b/src/components/mypage/MyReviews.tsx
@@ -73,9 +73,10 @@ export default function MyReviews({ myReviewsTab, setMyReviewsTab, onOpenReviewD
             :
             <section className='flex flex-col gap-4'>
               {createdReviews?.map((review: ReviewItem) => (
-                <div key={`${review?.Gathering?.id}-${review?.id}`}
-                  className={`relative w-full p-4 rounded-xl border-1 hover:border-main-200 hover:shadow-md transition-gathering-item ${myReviewsTab === 0 ? 'bg-main-apricot' : 'dark:bg-gray-700 dark:text-white'}`}
-                ><CreatedReview review={review} /></div>
+                <CreatedReview
+                  key={`${review?.Gathering?.id}-${review?.id}`}
+                  review={review}
+                />
               ))}
             </section>
         )

--- a/src/components/shared/DarkModeToggleButton.tsx
+++ b/src/components/shared/DarkModeToggleButton.tsx
@@ -97,7 +97,7 @@ const useThemeState = () => {
  * 테마 토글 버튼
  * @returns 테마 토글 버튼
  */
-export default function DarkModeToggleButton() {
+export function DarkModeToggleButton() {
     const { handleToggle, currentThemeInfo, nextThemeInfo } = useThemeState();
     const CurrentIcon = currentThemeInfo.icon;
 
@@ -135,5 +135,65 @@ export function DarkModeToggleWithLabel() {
                 {currentThemeInfo.label}
             </span>
         </button>
+    );
+}
+
+// =================================================================================================
+// 테마 선택 버튼 그룹
+// =================================================================================================
+
+const useThemeSelector = () => {
+    const { toggleDarkMode } = useTheme();
+    const [currentTheme, setCurrentTheme] = useState<ThemeMode>("system");
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            const savedTheme = localStorage.getItem("theme") as ThemeMode | null;
+            if (savedTheme) {
+                setCurrentTheme(savedTheme);
+            } else {
+                setCurrentTheme("system");
+            }
+        }
+    }, []);
+
+    const selectTheme = (theme: ThemeMode) => {
+        setCurrentTheme(theme);
+        toggleDarkMode(theme);
+    };
+
+    return {
+        currentTheme,
+        selectTheme,
+    };
+}
+
+export function ThemeSelectionButtons() {
+    const { currentTheme, selectTheme } = useThemeSelector();
+    const themes: ThemeMode[] = ["light", "dark", "system"];
+
+    return (
+        <div className="flex items-center gap-2 p-1 rounded-lg border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800">
+            {themes.map((theme) => {
+                const themeInfo = getThemeInfo(theme);
+                const Icon = themeInfo.icon;
+                const isActive = currentTheme === theme;
+
+                return (
+                    <button
+                        key={theme}
+                        onClick={() => selectTheme(theme)}
+                        className={`w-full flex items-center justify-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium transition-colors duration-200 ${isActive
+                            ? "bg-white dark:bg-gray-900/50 text-gray-800 dark:text-gray-100 shadow-sm"
+                            : "text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700/50"
+                            }`}
+                        aria-pressed={isActive}
+                        title={themeInfo.fullLabel}
+                    >
+                        <Icon size={16} className={isActive ? themeInfo.color : ""} />
+                    </button>
+                );
+            })}
+        </div>
     );
 }

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -6,8 +6,9 @@ import { useContext, useMemo } from 'react';
 import { AuthContext } from '@/providers/AuthProvider';
 import { validateProfileImage } from '@/utils/shared/validateProfileImage';
 import { shortenName } from '@/utils/shared/shortenName';
+import { AlignJustify } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/shadcn-ui/dropdown-menu';
-import DarkModeToggleButton from '@/components/shared/DarkModeToggleButton';
+import { DarkModeToggleButton, ThemeSelectionButtons } from '@/components/shared/DarkModeToggleButton';
 import TokenCountdown from '@/components/shared/TokenCountDown';
 import ImageWithFallback from '@/components/shared/ImageWithFallback';
 import Link from 'next/link';
@@ -60,7 +61,8 @@ export default function Navbar() {
                         )
                     })}
                 </section>
-                <section className='flex items-center gap-3'>
+                {/* sm 초과 태블릿, PC 프로필 메뉴 */}
+                <section className='hidden sm:flex items-center gap-3'>
                     {token && (
                         <>
                             <TokenCountdown />
@@ -103,6 +105,44 @@ export default function Navbar() {
                         </Link>
                     )}
                     <DarkModeToggleButton />
+                </section>
+
+                {/* sm 이하 모바일 프로필 메뉴 */}
+                <section className='sm:hidden block'>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger>
+                            <AlignJustify className='size-6 text-gray-800 dark:text-gray-200' />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent className='flex flex-col'>
+                            {token && (
+                                <>
+                                    <DropdownMenuLabel className='text-main-500 dark:text-main-400 p-1'>{shortenName(userName, 20)}</DropdownMenuLabel>
+                                    <DropdownMenuItem className='pl-1'><TokenCountdown /></DropdownMenuItem>
+                                    <DropdownMenuSeparator className='h-[0.1rem] bg-gray-300' />
+                                    <DropdownMenuItem className='text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 p-1 transition-colors duration-200'>
+                                        <Link href='/mypage'>마이페이지</Link>
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        onClick={() => signOut()}
+                                        className='cursor-pointer text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 p-1 transition-colors duration-200'
+                                    >
+                                        로그아웃
+                                    </DropdownMenuItem>
+                                </>
+                            )}
+                            {!token && (
+                                <DropdownMenuItem className='cursor-pointer text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 p-1 transition-colors duration-200'
+                                >
+                                    <Link href='/auth/signin' className='w-full'>
+                                        로그인
+                                    </Link>
+                                </DropdownMenuItem>
+                            )}
+                            <div className='flex justify-center'>
+                                <ThemeSelectionButtons />
+                            </div>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
                 </section>
             </main>
         </nav>

--- a/src/components/shared/TokenCountDown.tsx
+++ b/src/components/shared/TokenCountDown.tsx
@@ -26,5 +26,5 @@ export default function TokenCountdown() {
     const minutes = String(Math.floor(remaining / 60000)).padStart(2, '0');
     const seconds = String(Math.floor((remaining % 60000) / 1000)).padStart(2, '0');
 
-    return <span className='hidden md:block font-medium text-sm dark:text-white'>{minutes}:{seconds}</span>;
+    return <span className='font-medium text-sm dark:text-white'>{minutes}:{seconds}</span>;
 }

--- a/src/utils/mypage/constants/thumbnailConstants.ts
+++ b/src/utils/mypage/constants/thumbnailConstants.ts
@@ -1,3 +1,3 @@
 /** 마이페이지 모든 탭의 썸네일 사이즈 */
-export const THUMBNAIL_WIDTH = 'w-full sm:w-[17.5rem]';
-export const THUMBNAIL_CLASSNAME = 'h-[10rem] rounded-xl object-cover pointer-events-none';
+export const THUMBNAIL_SIZE = 'w-full sm:w-[17.5rem] h-full';
+export const THUMBNAIL_CLASSNAME = 'rounded-xl object-cover pointer-events-none';


### PR DESCRIPTION
## 📌 마이페이지 motion(m) 애니메이션 구현
- 참여중인 모임, 나의 리뷰(작성가능한 리뷰/작성한 리뷰), 내가 만든 모임
- 투명도 0에서 100 + 왼쪽에서 원위치로 등장하는 애니메이션을 모임 카드에 부여함

## 📌 마이페이지 각 탭의 모임카드 썸네일, 모임 상세 썸네일 해상도 수정
- 실제 렌더 크기에 맞춰 width와 height을 조정하고 sizes 속성 삭제

## 📌 네비게이션바 모바일 반응형 버거메뉴 구현
- ThemeSelectionButtons 컴포넌트 신규 구현
- sm 이하일 때 우측에 버거 메뉴 표시. 토글 드롭다운
- 유저 이름, 카운트다운, 마이페이지, 로그아웃, 다크/라이트 버튼 리스트 포함

## 📌 랜딩페이지 반응형 수정
- 헤더에서 모바일일 때는 버튼이 h1 오른쪽에 가도록 수정

## 📌 모임 생성 다이얼로그 반응형 수정
- 서비스 선택에서 flex를 모바일일 때는 flex-col이 되게 수정