### PR TITLE
[fix] 참석한 모임 목록 조회 버그 해결, 네브바와 랜딩페이지 새로고침시 이미지 검은색 사각형 반짝이는 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# temporary files
+tmp/
+temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Core Commands
+- `pnpm dev` - Start development server
+- `pnpm build` - Build for production  
+- `pnpm start` - Start production server
+- `pnpm lint` - Run ESLint
+- `pnpm analyze` - Build with bundle analyzer
+
+### Testing Commands
+- `pnpm test` - Run tests in watch mode
+- `pnpm test:run` - Run tests once
+- `pnpm test:coverage` - Run tests with coverage report
+
+## Architecture Overview
+
+### Feature-Based Architecture
+The codebase follows a feature-based organization pattern:
+
+```
+src/
+├── components/
+│   ├── auth/           # Authentication components
+│   ├── gatherings/     # Meeting-related components
+│   ├── mypage/         # User profile components  
+│   ├── reviews/        # Review components
+│   ├── saved/          # Saved meetings components
+│   ├── shadcn-ui/      # UI library components
+│   └── shared/         # Global reusable components
+├── hooks/api/          # API hooks using Tanstack Query
+├── utils/              # Utility functions by feature
+└── queries/            # Query key factories
+```
+
+### "Async Surf" Pattern
+This project implements a custom "Async Surf" pattern for managing client-server async flows:
+
+#### Client Side Components:
+- **API Hooks** (`hooks/api/`): Custom hooks wrapping Tanstack Query operations
+- **Queries Station** (`queries/`): Centralized query key management using Query Factory pattern
+- **API Paths Station** (`lib/api/apiPaths.ts`): Centralized API endpoint definitions
+  - `EXTERNAL_PATHS`: API routes → Backend
+  - `INTERNAL_PATHS`: Client → API routes
+- **Client Fetchers** (`lib/api/clientFetchers.ts`): Axios-based HTTP clients with interceptors
+- **Surf Guard** (`lib/api/surfGuard.ts`): Consistent error handling utilities
+
+#### Server Side Components:
+- **Server Fetcher** (`lib/api/serverFetcher.ts`): Fetch API wrapper for server-side requests with Next.js optimizations
+
+### State Management
+- **Tanstack Query**: Server state management
+- **Context API**: Global client state (auth, theme)
+- **React Hook Form + Zod**: Form state and validation
+
+### Key Libraries
+- **Next.js 15**: React framework with App Router
+- **TypeScript**: Type safety
+- **Tailwind CSS + shadcn/ui**: Styling
+- **Vitest + MSW**: Testing
+- **Motion**: Animations
+
+## Important Patterns
+
+### API Integration
+- All API calls go through custom hooks in `hooks/api/`
+- Query keys are centralized in `queries/` files
+- Error handling is standardized through Surf Guard utilities
+- Client-server communication follows the Async Surf pattern
+
+### Component Organization
+- Components are grouped by feature (auth, gatherings, reviews, etc.)
+- `shared/` contains globally reusable components
+- Each feature may have its own `shared/` subdirectory for feature-specific reusable components
+
+### Form Handling
+- Use React Hook Form with Zod validation schemas
+- Form schemas are located in `utils/[feature]/` directories
+- XSS protection is implemented via `escapeForXSS` utility
+
+### Path Aliases
+- `@/*` maps to `src/*` (configured in tsconfig.json)
+
+## Testing Setup
+- Vitest with jsdom environment
+- MSW for API mocking
+- Setup file: `src/__test__/setup.ts`
+- Test files alongside source code with `.test.ts` suffix

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Meet Meet 1.0 ver
+# Meet Meet
 
 <img src='https://github.com/user-attachments/assets/7dc46ff1-32ea-40e8-8237-3d53cb78d9a4' width='300' height='300' />
 

--- a/src/components/shared/ImageWithFallback.tsx
+++ b/src/components/shared/ImageWithFallback.tsx
@@ -39,7 +39,7 @@ export default function ImageWithFallback(props: ImageWithFallbackProps) {
             decoding={priority ? 'sync' : 'async'}
             quality={quality}
             placeholder={placeholder}
-            blurDataURL={placeholder === 'blur' ? "data:image/png;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=" : undefined}
+            blurDataURL={placeholder === 'blur' ? "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMSIgaGVpZ2h0PSIxIiB2aWV3Qm94PSIwIDAgMSAxIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxIiBoZWlnaHQ9IjEiIGZpbGw9InRyYW5zcGFyZW50Ii8+PC9zdmc+" : undefined}
             unoptimized={false}
         />
     );

--- a/src/lib/api/apiPaths.ts
+++ b/src/lib/api/apiPaths.ts
@@ -52,7 +52,7 @@ export const INTERNAL_PATHS = {
     USER: '/api/auth/user',
     GATHERINGS: '/api/gatherings',
     REVIEWS: `/api/reviews`,
-    CHECK_JOINED: `/api/gatherings/joined`,
+    CHECK_JOINED: `/api/gatherings/joined?&limit=100`,
     fetchGatheringDetail: (id: number) => `/api/gatherings/detail?id=${id}`,
     fetchGatheringParticipants: (id: number) => `/api/gatherings/participants?id=${id}`,
     joinGathering: (id: number) => `/api/gatherings/join?id=${id}`,


### PR DESCRIPTION
## 📌 참석한 모임 목록 조회 버그 해결
- `/api/gatherings/joined`으로 보내면 최대 10개의 모임만 조회할 수 있어서 11개부터 참여 중임에도 react query 캐시에 문제가 있었음
- '?&limit=100'을 추가해서 100개까지 최대 갯수를 늘려줌.

## 📌 네브바와 랜딩페이지 새로고침시 이미지 검은색 사각형 반짝이는 문제 해결
- placeholder에 blur 설정을 해두고, Image의 blurDataURL에 검은색 base64 svg로 되어있던게 원인이었음
- 투명으로 변경